### PR TITLE
Version 7.2.1

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.magmaguy</groupId>
     <artifactId>EliteMobs</artifactId>
-    <version>7.2.0</version>
+    <version>7.2.1</version>
     <build>
         <defaultGoal>clean resources:resources package</defaultGoal>
         <finalName>${project.artifactId}</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.magmaguy</groupId>
     <artifactId>EliteMobs</artifactId>
-    <version>7.2.0</version>
+    <version>7.2.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
+++ b/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
@@ -94,6 +94,7 @@ public class EventsRegistrer {
         pluginManager.registerEvents(new PigHandler(), plugin);
         pluginManager.registerEvents(new SheepHandler(), plugin);
         pluginManager.registerEvents(new FindSuperMobs(), plugin);
+        pluginManager.registerEvents(new ItemEnchantmentPrevention(), plugin);
 
         //Mob damage
         pluginManager.registerEvents(new PlayerDamagedByEliteMobHandler(), plugin);

--- a/src/main/java/com/magmaguy/elitemobs/adventurersguild/GuildRank.java
+++ b/src/main/java/com/magmaguy/elitemobs/adventurersguild/GuildRank.java
@@ -104,7 +104,7 @@ public class GuildRank {
     }
 
     public static double currencyBonusMultiplier(int prestigeLevel) {
-        return 1 + prestigeLevel / 2D;
+        return 1 + prestigeLevel * 5;
     }
 
     /**

--- a/src/main/java/com/magmaguy/elitemobs/adventurersguild/GuildRankMenuHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/adventurersguild/GuildRankMenuHandler.java
@@ -337,8 +337,7 @@ public class GuildRankMenuHandler implements Listener {
         payout * 1000 = amount of elite mobs to kill before going up a rank
          */
         double eliteMobsToKillBeforeGuildRankup = 100 + 500 * (tier - 1) * 0.1;
-        return (int) (((tier - 1) * 10 / 2 * eliteMobsToKillBeforeGuildRankup)
-                + (tier - 1) * 10 / 2 * eliteMobsToKillBeforeGuildRankup * (prestigeLevel / 2));
+        return (int) ((tier - 1) * 10 / 2 * eliteMobsToKillBeforeGuildRankup * (GuildRank.currencyBonusMultiplier(prestigeLevel)));
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/api/EliteMobEnterCombatEvent.java
+++ b/src/main/java/com/magmaguy/elitemobs/api/EliteMobEnterCombatEvent.java
@@ -49,9 +49,9 @@ public class EliteMobEnterCombatEvent extends Event {
                                     continue;
                                 return;
                             }
-                            cancel();
-                            Bukkit.getServer().getPluginManager().callEvent(new EliteMobExitCombatEvent(eliteMobEntity));
                         }
+                        cancel();
+                        Bukkit.getServer().getPluginManager().callEvent(new EliteMobExitCombatEvent(eliteMobEntity));
                     }
 
             }

--- a/src/main/java/com/magmaguy/elitemobs/collateralminecraftchanges/ItemEnchantmentPrevention.java
+++ b/src/main/java/com/magmaguy/elitemobs/collateralminecraftchanges/ItemEnchantmentPrevention.java
@@ -1,0 +1,20 @@
+package com.magmaguy.elitemobs.collateralminecraftchanges;
+
+import com.magmaguy.elitemobs.config.ItemSettingsConfig;
+import com.magmaguy.elitemobs.items.EliteItemLore;
+import com.magmaguy.elitemobs.items.ItemTagger;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.enchantment.EnchantItemEvent;
+
+public class ItemEnchantmentPrevention implements Listener {
+    @EventHandler(ignoreCancelled = true)
+    public void onEnchant(EnchantItemEvent event) {
+        if (!ItemSettingsConfig.preventEliteItemEnchantment) {
+            new EliteItemLore(event.getItem(), false);
+            return;
+        }
+        if (ItemTagger.isEliteItem(event.getItem()))
+            event.setCancelled(true);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/combatsystem/CombatSystem.java
+++ b/src/main/java/com/magmaguy/elitemobs/combatsystem/CombatSystem.java
@@ -15,13 +15,15 @@ public class CombatSystem {
      */
     public static final double TARGET_HITS_TO_KILL = 7; //affects max health assignment on EliteMobEntity.java
 
-    public static final int TRIDENT = 9;
+    //this sets the tier of various materials
+    public static final int TRIDENT_TIER_LEVEL = 9;
     public static final int NETHERITE_TIER_LEVEL = 8;
     public static final int DIAMOND_TIER_LEVEL = 7;
     public static final int IRON_TIER_LEVEL = 6;
     public static final int STONE_CHAIN_TIER_LEVEL = 5;
     public static final int GOLD_WOOD_LEATHER_TIER_LEVEL = 3;
 
+    //this bypasses the damage system, outputting a raw damage value
     public static boolean bypass = false;
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/commands/AdminCommands.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/AdminCommands.java
@@ -3,9 +3,12 @@ package com.magmaguy.elitemobs.commands;
 import com.magmaguy.elitemobs.commands.admin.DebugScreen;
 import com.magmaguy.elitemobs.commands.admin.StatsCommand;
 import com.magmaguy.elitemobs.commands.admin.npc.NPCCommands;
+import com.magmaguy.elitemobs.items.ItemTagger;
+import com.magmaguy.elitemobs.items.customenchantments.SoulbindEnchantment;
 import com.magmaguy.elitemobs.thirdparty.discordsrv.DiscordSRVAnnouncement;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 public class AdminCommands {
 
@@ -157,6 +160,15 @@ public class AdminCommands {
                         if (i > 0)
                             message.append(args[i] + " ");
                     new DiscordSRVAnnouncement(message.toString());
+                }
+                return true;
+
+            case "unbind":
+                if (CommandHandler.userPermCheck("elitemobs.*", commandSender)) {
+                    Player player = (Player) commandSender;
+                    ItemStack itemStack = player.getInventory().getItemInMainHand();
+                    if (ItemTagger.isEliteItem(itemStack))
+                        SoulbindEnchantment.removeEnchantment(itemStack);
                 }
                 return true;
 

--- a/src/main/java/com/magmaguy/elitemobs/commands/GetLootCommandHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/GetLootCommandHandler.java
@@ -11,7 +11,7 @@ public class GetLootCommandHandler {
     public static boolean getLoot(Player player, String args1) {
         CustomItem customItem = CustomItem.getCustomItem(args1);
         if (customItem == null) return false;
-        player.getInventory().addItem(customItem.generateDefaultsItemStack());
+        player.getInventory().addItem(customItem.generateDefaultsItemStack(player, false));
         return true;
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/commands/KillHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/KillHandler.java
@@ -53,7 +53,7 @@ public class KillHandler {
 
             int counter = 0;
 
-            Iterator<EliteMobEntity> eliteMobEntityIterator = EntityTracker.getEliteMobs().iterator();
+            Iterator<EliteMobEntity> eliteMobEntityIterator = EntityTracker.getEliteMobs().values().iterator();
 
             while (eliteMobEntityIterator.hasNext()) {
                 EliteMobEntity eliteMobEntity = eliteMobEntityIterator.next();

--- a/src/main/java/com/magmaguy/elitemobs/commands/SimLootHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/SimLootHandler.java
@@ -39,7 +39,7 @@ public class SimLootHandler {
     }
 
     public static void simLoot(Player player, int level) {
-        ItemStack itemStack = ItemConstructor.constructItem(level, null);
+        ItemStack itemStack = ItemConstructor.constructItem(level, null, null, false);
         player.getWorld().dropItem(player.getLocation(), itemStack);
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/commands/TierSetSpawner.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/TierSetSpawner.java
@@ -18,15 +18,15 @@ public class TierSetSpawner {
         ItemStack axe = new ItemStack(Material.NETHERITE_AXE);
         ItemStack bow = new ItemStack(Material.BOW);
 
-        if (tierLevel > 1) {
+        if (tierLevel > 8) {
 
-            applyEnchantment(helmet, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel);
-            applyEnchantment(chestplate, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel);
-            applyEnchantment(leggings, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel);
-            applyEnchantment(boots, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel);
-            applyEnchantment(sword, Enchantment.DAMAGE_ALL, tierLevel);
-            applyEnchantment(axe, Enchantment.DAMAGE_ALL, tierLevel);
-            applyEnchantment(bow, Enchantment.ARROW_DAMAGE, tierLevel);
+            applyEnchantment(helmet, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel - 8);
+            applyEnchantment(chestplate, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel - 8);
+            applyEnchantment(leggings, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel - 8);
+            applyEnchantment(boots, Enchantment.PROTECTION_ENVIRONMENTAL, tierLevel - 8);
+            applyEnchantment(sword, Enchantment.DAMAGE_ALL, tierLevel - 8);
+            applyEnchantment(axe, Enchantment.DAMAGE_ALL, tierLevel - 8);
+            applyEnchantment(bow, Enchantment.ARROW_DAMAGE, tierLevel - 8);
 
         }
 
@@ -37,8 +37,6 @@ public class TierSetSpawner {
         player.getInventory().addItem(sword);
         player.getInventory().addItem(axe);
         player.getInventory().addItem(bow);
-
-        return;
 
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/commands/UserCommands.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/UserCommands.java
@@ -9,9 +9,11 @@ import com.magmaguy.elitemobs.commands.quest.QuestStatusCommand;
 import com.magmaguy.elitemobs.commands.shops.CustomShopMenu;
 import com.magmaguy.elitemobs.commands.shops.ProceduralShopMenu;
 import com.magmaguy.elitemobs.config.DefaultConfig;
+import com.magmaguy.elitemobs.items.EliteItemLore;
 import com.magmaguy.elitemobs.items.ShareItem;
 import com.magmaguy.elitemobs.mobconstructor.custombosses.CustomBossEntity;
 import com.magmaguy.elitemobs.playerdata.PlayerStatusScreen;
+import com.magmaguy.elitemobs.utils.WarningMessage;
 import org.bukkit.entity.Player;
 
 import java.util.UUID;
@@ -136,6 +138,10 @@ public class UserCommands {
                 }
                 return true;
 
+            case "updateitem":
+                new EliteItemLore(player.getItemInHand(), false);
+                new WarningMessage("Updated item!");
+                return true;
             default:
                 return false;
         }

--- a/src/main/java/com/magmaguy/elitemobs/commands/shops/CustomShopMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/shops/CustomShopMenu.java
@@ -80,9 +80,9 @@ public class CustomShopMenu implements Listener {
 
         for (int i : CustomShopMenuConfig.storeSlots) {
 
-            int itemEntryIndex = random.nextInt(CustomItem.getCustomItemStackList().size());
+            int itemEntryIndex = random.nextInt(CustomItem.getCustomItemStackShopList().size());
 
-            ItemStack itemStack = CustomItem.getCustomItemStackList().get(itemEntryIndex).clone();
+            ItemStack itemStack = CustomItem.getCustomItemStackShopList().get(itemEntryIndex).clone();
             ItemWorthSwitcher.switchToWorth(itemStack);
 
             shopInventory.setItem(i, itemStack);

--- a/src/main/java/com/magmaguy/elitemobs/commands/shops/ProceduralShopMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/shops/ProceduralShopMenu.java
@@ -64,7 +64,7 @@ public class ProceduralShopMenu implements Listener {
 
             int randomTier = random.nextInt(balancedMax) + balancedMin;
 
-            ItemStack itemStack = ItemConstructor.constructItem(randomTier, null);
+            ItemStack itemStack = ItemConstructor.constructItem(randomTier, null, null, true);
             ItemWorthSwitcher.switchToWorth(itemStack);
 
             shopInventory.setItem(i, itemStack);

--- a/src/main/java/com/magmaguy/elitemobs/config/EconomySettingsConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/EconomySettingsConfig.java
@@ -20,7 +20,8 @@ public class EconomySettingsConfig {
     public static double currencyShowerMultiplier;
     public static String chatCurrencyShowerMessage;
     public static String actionBarCurrencyShowerMessage;
-    public static String lootShowerMaterial1, lootShowerMaterial5, lootShowerMaterial10, lootShowerMaterial20, lootShowerMaterial50;
+    public static String lootShowerMaterial1, lootShowerMaterial5, lootShowerMaterial10, lootShowerMaterial20,
+            lootShowerMaterial50, lootShowerMaterial100, lootShowerMaterial500, lootShowerMaterial1000;
     public static String adventurersGuildNotificationMessage;
     public static double defaultMaterialWorth;
     private static FileConfiguration thisConfiguration;
@@ -31,7 +32,7 @@ public class EconomySettingsConfig {
         FileConfiguration fileConfiguration = ConfigurationEngine.fileConfigurationCreator(file);
 
         double netheriteLevel = CombatSystem.NETHERITE_TIER_LEVEL + 10;
-        double tridentLevel = CombatSystem.TRIDENT + 10;
+        double tridentLevel = CombatSystem.TRIDENT_TIER_LEVEL + 10;
         double diamondLevel = CombatSystem.DIAMOND_TIER_LEVEL + 10;
         double ironLevel = CombatSystem.IRON_TIER_LEVEL + 10;
         double stoneChainLevel = CombatSystem.STONE_CHAIN_TIER_LEVEL + 10;
@@ -50,6 +51,9 @@ public class EconomySettingsConfig {
         lootShowerMaterial10 = ConfigurationEngine.setString(fileConfiguration, "lootShowerMaterial.10", Material.GOLD_BLOCK.name());
         lootShowerMaterial20 = ConfigurationEngine.setString(fileConfiguration, "lootShowerMaterial.20", Material.EMERALD.name());
         lootShowerMaterial50 = ConfigurationEngine.setString(fileConfiguration, "lootShowerMaterial.50", Material.EMERALD_BLOCK.name());
+        lootShowerMaterial100 = ConfigurationEngine.setString(fileConfiguration, "lootShowerMaterial.100", Material.DIAMOND.name());
+        lootShowerMaterial500 = ConfigurationEngine.setString(fileConfiguration, "lootShowerMaterial.500", Material.DIAMOND_BLOCK.name());
+        lootShowerMaterial1000 = ConfigurationEngine.setString(fileConfiguration, "lootShowerMaterial.1000", Material.NETHER_STAR.name());
         adventurersGuildNotificationMessage = ConfigurationEngine.setString(fileConfiguration, "adventurersGuildNotificationMessages", "&7[EM] Extra spending money? Try &a/em !");
 
         addMaterial(fileConfiguration, Material.DIAMOND_AXE, diamondLevel);

--- a/src/main/java/com/magmaguy/elitemobs/config/ItemSettingsConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/ItemSettingsConfig.java
@@ -24,6 +24,14 @@ public class ItemSettingsConfig {
     public static String eliteEnchantLoreString;
     public static boolean useHoesAsWeapons;
     public static boolean enableRareItemParticleEffects;
+    public static String prestigeName;
+    public static String potionEffectOnHitTargetLore, potionEffectOnHitSelfLore, potionEffectContinuousLore;
+    public static String eliteEnchantmentColor;
+    public static String vanillaEnchantmentColor;
+    public static String customEnchantmentColor;
+    public static String potionEffectColor;
+    public static String noSoulbindLore;
+    public static boolean preventEliteItemEnchantment;
 
     public static void initializeConfig() {
         File file = ConfigurationEngine.fileCreator("ItemSettings.yml");
@@ -32,20 +40,27 @@ public class ItemSettingsConfig {
         doEliteMobsLoot = ConfigurationEngine.setBoolean(fileConfiguration, "doEliteMobsLoot", true);
         doMmorpgColors = ConfigurationEngine.setBoolean(fileConfiguration, "doMMORPGColorsForItems", true);
         preventCustomItemPlacement = ConfigurationEngine.setBoolean(fileConfiguration, "preventCustomItemPlacement", true);
-        loreStructure = ConfigurationEngine.setList(fileConfiguration, "itemLoreStructure", Arrays.asList(
-                ChatColorConverter.convert("$enchantments"),
-                ChatColorConverter.convert("$potionEffect"),
-                ChatColorConverter.convert("&m----------------------"),
-                ChatColorConverter.convert("$customLore"),
+        loreStructure = ConfigurationEngine.setList(fileConfiguration, "itemLoreStructures", Arrays.asList(
+                ChatColorConverter.convert("&7&m&l---------&7<&lEquip Info&7>&m&l---------"),
+                ChatColorConverter.convert("&7Item level: &f$itemLevel &7Prestige &6$prestigeLevel"),
+                ChatColorConverter.convert("$soulbindInfo"),
                 ChatColorConverter.convert("$itemSource"),
-                ChatColorConverter.convert("$loreResaleValue"),
-                ChatColorConverter.convert("Elite Mobs drop"),
-                ChatColorConverter.convert("&m----------------------"),
-                ChatColorConverter.convert("Tier $tier ")));
-        shopItemSource = ConfigurationEngine.setString(fileConfiguration, "shopSourceItemLore", "Purchased from a store");
-        mobItemSource = ConfigurationEngine.setString(fileConfiguration, "mobSourceItemLore", "Looted from $mob");
-        loreWorth = ConfigurationEngine.setString(fileConfiguration, "loreWorth", "Worth $worth $currencyName");
-        loreResale = ConfigurationEngine.setString(fileConfiguration, "loreResaleValue", "Sells for $resale $currencyName");
+                ChatColorConverter.convert("$ifLore&7&m&l-----------&7< &f&lLore&7 >&m&l-----------"),
+                ChatColorConverter.convert("$customLore"),
+                ChatColorConverter.convert("$ifEnchantments&7&m&l--------&7<&9&lEnchantments&7>&m&l--------"),
+                ChatColorConverter.convert("$enchantments"),
+                ChatColorConverter.convert("$eliteEnchantments"),
+                ChatColorConverter.convert("$ifCustomEnchantments&7&m&l------&7< &3&lCustom Enchants&7 >&m&l------"),
+                ChatColorConverter.convert("$customEnchantments"),
+                ChatColorConverter.convert("$ifPotionEffects&7&m&l----------&7< &5&lEffects&7 >&m&l----------"),
+                ChatColorConverter.convert("$potionEffect"),
+                ChatColorConverter.convert("&7&l&m-----------------------------"),
+                ChatColorConverter.convert("$loreResaleValue")
+        ));
+        shopItemSource = ConfigurationEngine.setString(fileConfiguration, "shopSourceItemLores", "&7Purchased from a store");
+        mobItemSource = ConfigurationEngine.setString(fileConfiguration, "mobSourceItemLores", "&7Looted from $mob");
+        loreWorth = ConfigurationEngine.setString(fileConfiguration, "loreWorths", "&7Worth $worth $currencyName");
+        loreResale = ConfigurationEngine.setString(fileConfiguration, "loreResaleValues", "&7Sells for $resale $currencyName");
         flatDropRate = ConfigurationEngine.setDouble(fileConfiguration, "flatDropRate", 0.25);
         tierIncreaseDropRate = ConfigurationEngine.setDouble(fileConfiguration, "tierIncreaseDropRate", 0.05);
         proceduralItemWeight = ConfigurationEngine.setDouble(fileConfiguration, "proceduralItemDropWeight", 90);
@@ -59,9 +74,19 @@ public class ItemSettingsConfig {
         maximumLootTier = ConfigurationEngine.setInt(fileConfiguration, "maximumLootTier", 100);
         useEliteEnchantments = ConfigurationEngine.setBoolean(fileConfiguration, "useEliteEnchantments", true);
         doRareDropsEffect = ConfigurationEngine.setBoolean(fileConfiguration, "doRareDropsEffect", true);
-        eliteEnchantLoreString = ChatColorConverter.convert(ConfigurationEngine.setString(fileConfiguration, "eliteEnchantmentLoreString", "&6Elite"));
+        eliteEnchantLoreString = ChatColorConverter.convert(ConfigurationEngine.setString(fileConfiguration, "eliteEnchantmentLoreStrings", "Elite"));
         useHoesAsWeapons = ConfigurationEngine.setBoolean(fileConfiguration, "useHoesAsWeapons", false);
         enableRareItemParticleEffects = ConfigurationEngine.setBoolean(fileConfiguration, "enableRareItemParticleEffects", true);
+        prestigeName = ConfigurationEngine.setString(fileConfiguration, "prestigeNameOnItems", "Prestige");
+        potionEffectOnHitTargetLore = ConfigurationEngine.setString(fileConfiguration, "potionEffectOnHitTargetLore", "&4⚔☠");
+        potionEffectOnHitSelfLore = ConfigurationEngine.setString(fileConfiguration, "potionEffectOnHitSelfLore", "&9⚔🛡");
+        potionEffectContinuousLore = ConfigurationEngine.setString(fileConfiguration, "potionEffectContinuousLore", "&6⟲");
+        eliteEnchantmentColor = ConfigurationEngine.setString(fileConfiguration, "eliteEnchantmentLoreColor", "&9◇");
+        vanillaEnchantmentColor = ConfigurationEngine.setString(fileConfiguration, "vanillaEnchantmentLoreColor", "&7◇");
+        customEnchantmentColor = ConfigurationEngine.setString(fileConfiguration, "customEnchantmentColor", "&3◇");
+        potionEffectColor = ConfigurationEngine.setString(fileConfiguration, "potionEffectLoreColor", "&5◇");
+        noSoulbindLore = ConfigurationEngine.setString(fileConfiguration, "noSoulbindLore", "&7Not Soulbound!");
+        preventEliteItemEnchantment = ConfigurationEngine.setBoolean(fileConfiguration, "preventEliteItemEnchantment", true);
 
         ConfigurationEngine.fileSaverOnlyDefaults(fileConfiguration, file);
     }

--- a/src/main/java/com/magmaguy/elitemobs/config/custombosses/CustomBossConfigFields.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/custombosses/CustomBossConfigFields.java
@@ -369,7 +369,7 @@ public class CustomBossConfigFields {
 
         }
 
-        this.followRange = configuration.getInt("followRange");
+        this.followRange = configuration.getInt("followDistance");
 
         this.leashRadius = configuration.getDouble("leashRadius");
 

--- a/src/main/java/com/magmaguy/elitemobs/config/enchantments/premade/SoulbindConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/enchantments/premade/SoulbindConfig.java
@@ -9,7 +9,7 @@ public class SoulbindConfig extends EnchantmentsConfigFields {
                 "Soulbind",
                 1,
                 10);
-        super.getAdditionalConfigOptions().put("loreString", "&6Soulbound to &f$player");
+        super.getAdditionalConfigOptions().put("loreStrings", "&7Soulbound to &f$player");
         super.getAdditionalConfigOptions().put("hologramString", "$player&f's");
     }
 }

--- a/src/main/java/com/magmaguy/elitemobs/events/mobs/Kraken.java
+++ b/src/main/java/com/magmaguy/elitemobs/events/mobs/Kraken.java
@@ -2,7 +2,6 @@ package com.magmaguy.elitemobs.events.mobs;
 
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.config.events.premade.KrakenEventConfig;
-import com.magmaguy.elitemobs.items.customitems.CustomItem;
 import com.magmaguy.elitemobs.powers.ProjectileLocationGenerator;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -22,7 +21,7 @@ import java.util.UUID;
 
 public class Kraken implements Listener {
 
-    private static HashSet<Squid> krakens = new HashSet<>();
+    private static final HashSet<Squid> krakens = new HashSet<>();
 
     public static boolean isKraken(Squid kraken) {
         return krakens.contains(kraken);
@@ -32,7 +31,7 @@ public class Kraken implements Listener {
         krakens.remove(kraken);
     }
 
-    private static HashSet<Fireball> fireballs = new HashSet<>();
+    private static final HashSet<Fireball> fireballs = new HashSet<>();
 
     public static boolean isFireball(Fireball fireball) {
         return fireballs.contains(fireball);
@@ -137,7 +136,7 @@ public class Kraken implements Listener {
 
         new BukkitRunnable() {
 
-            UUID uuid = kraken.getUniqueId();
+            final UUID uuid = kraken.getUniqueId();
 
             @Override
             public void run() {
@@ -211,7 +210,7 @@ public class Kraken implements Listener {
         if (!event.getEntity().getType().equals(EntityType.SQUID)) return;
         if (!isKraken((Squid) event.getEntity())) return;
 
-        event.getEntity().getWorld().dropItem(event.getEntity().getLocation(), CustomItem.getCustomItem("depths_seeker.yml").generateItemStack(10));
+        //event.getEntity().getWorld().dropItem(event.getEntity().getLocation(), CustomItem.getCustomItem("depths_seeker.yml").generateItemStack(10));
         removeKraken((Squid) event.getEntity());
 
     }

--- a/src/main/java/com/magmaguy/elitemobs/items/EliteItemLore.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/EliteItemLore.java
@@ -1,0 +1,237 @@
+package com.magmaguy.elitemobs.items;
+
+import com.magmaguy.elitemobs.ChatColorConverter;
+import com.magmaguy.elitemobs.api.EliteMobsItemDetector;
+import com.magmaguy.elitemobs.config.EconomySettingsConfig;
+import com.magmaguy.elitemobs.config.ItemSettingsConfig;
+import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfig;
+import com.magmaguy.elitemobs.config.potioneffects.PotionEffectsConfig;
+import com.magmaguy.elitemobs.items.customenchantments.CustomEnchantment;
+import com.magmaguy.elitemobs.items.customenchantments.SoulbindEnchantment;
+import com.magmaguy.elitemobs.items.potioneffects.ElitePotionEffect;
+import com.magmaguy.elitemobs.items.potioneffects.ElitePotionEffectContainer;
+import com.magmaguy.elitemobs.mobconstructor.EliteMobEntity;
+import com.magmaguy.elitemobs.utils.WarningMessage;
+import org.bukkit.ChatColor;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class EliteItemLore {
+
+    ItemStack itemStack;
+    ItemMeta itemMeta;
+    ArrayList<String> vanillaEnchantmentsLore = new ArrayList<>();
+    HashMap<Enchantment, Integer> eliteVanillaEnchantments = new HashMap<>();
+    ArrayList<String> eliteVanillaEnchantmentsLore = new ArrayList<>();
+    HashMap<CustomEnchantment, Integer> customEnchantments = new HashMap<>();
+    ArrayList<String> customEnchantmentLore = new ArrayList<>();
+    List<String> potionListLore = new ArrayList<>();
+    List<String> lore;
+    String soulbindInfo = null;
+    boolean showItemWorth;
+    String itemWorth = null;
+    String itemSource = null;
+    EliteMobEntity eliteMobEntity;
+    List<String> customLore = new ArrayList<>();
+    int prestigeLevel = 0;
+
+
+    public EliteItemLore(ItemStack itemStack, boolean showItemWorth) {
+
+        if (!EliteMobsItemDetector.isEliteMobsItem(itemStack)) {
+            new WarningMessage("Attempted to rewrite the lore of a non-elitemobs item! This is not supposed to happen.");
+            return;
+        }
+
+        this.itemStack = itemStack;
+        this.itemMeta = itemStack.getItemMeta();
+        this.lore = new ArrayList<>();
+        this.showItemWorth = showItemWorth;
+
+        constructVanillaEnchantments();
+
+        parseAllEliteEnchantments();
+        constructEliteEnchantments();
+
+        parseCustomEnchantments();
+        constructCustomEnchantments();
+
+        constructSoulbindEntry();
+        constructItemWorth();
+        constructItemSource();
+        constructCustomLore();
+        constructPrestigeLevel();
+
+        constructPotionEffects();
+
+        writeNewLore();
+
+        this.itemMeta.setLore(lore);
+        this.itemStack.setItemMeta(this.itemMeta);
+
+    }
+
+    private void constructVanillaEnchantments() {
+        for (Enchantment enchantment : itemMeta.getEnchants().keySet())
+            if (enchantment.getName().contains("CURSE"))
+                vanillaEnchantmentsLore.add(ChatColorConverter.convert(
+                        "&c" + EnchantmentsConfig.getEnchantment(enchantment).getName() + " "
+                                + itemMeta.getEnchants().get(enchantment)));
+            else
+                vanillaEnchantmentsLore.add(ChatColorConverter.convert(
+                        "&7" + EnchantmentsConfig.getEnchantment(enchantment).getName() + " "
+                                + itemMeta.getEnchants().get(enchantment)));
+    }
+
+    private void parseAllEliteEnchantments() {
+        parseEliteEnchantments(Enchantment.DAMAGE_ALL);
+        parseEliteEnchantments(Enchantment.ARROW_DAMAGE);
+        parseEliteEnchantments(Enchantment.DAMAGE_ARTHROPODS);
+        parseEliteEnchantments(Enchantment.DAMAGE_UNDEAD);
+        parseEliteEnchantments(Enchantment.PROTECTION_ENVIRONMENTAL);
+        parseEliteEnchantments(Enchantment.PROTECTION_PROJECTILE);
+        parseEliteEnchantments(Enchantment.PROTECTION_EXPLOSIONS);
+    }
+
+    private void parseEliteEnchantments(Enchantment enchantment) {
+        int enchantmentLevel = ItemTagger.getEnchantment(itemMeta, enchantment.getKey());
+        if (enchantmentLevel > 0)
+            eliteVanillaEnchantments.put(enchantment, enchantmentLevel);
+    }
+
+    private void constructEliteEnchantments() {
+        for (Enchantment enchantment : eliteVanillaEnchantments.keySet())
+            eliteVanillaEnchantmentsLore.add(ChatColorConverter.convert(
+                    "&7" + ItemSettingsConfig.eliteEnchantLoreString + " "
+                            + EnchantmentsConfig.getEnchantment(enchantment).getName()
+                            + " " + eliteVanillaEnchantments.get(enchantment)));
+
+    }
+
+    /**
+     * Note: This excludes the soulbind enchantment as it doesn't store an integer value
+     */
+    private void parseCustomEnchantments() {
+        for (CustomEnchantment customEnchantment : CustomEnchantment.getCustomEnchantments()) {
+            int enchantmentLevel = ItemTagger.getEnchantment(itemMeta, customEnchantment.getKey());
+            if (enchantmentLevel > 0)
+                customEnchantments.put(customEnchantment, enchantmentLevel);
+        }
+    }
+
+    private void constructCustomEnchantments() {
+        for (CustomEnchantment customEnchantment : customEnchantments.keySet())
+            customEnchantmentLore.add(ChatColorConverter.convert
+                    ("&6" + customEnchantment.getEnchantmentsConfigFields().getName() + " "
+                            + customEnchantments.get(customEnchantment)));
+    }
+
+    private void constructSoulbindEntry() {
+        Player player = SoulbindEnchantment.getSoulboundPlayer(itemMeta);
+        if (player == null) {
+            soulbindInfo = ChatColorConverter.convert(ItemSettingsConfig.noSoulbindLore);
+            return;
+        }
+        soulbindInfo = ChatColorConverter.convert(
+                EnchantmentsConfig.getEnchantment("soulbind.yml")
+                        .getFileConfiguration()
+                        .getString("loreStrings")
+                        .replace("$player", player.getDisplayName()));
+    }
+
+    private void constructPrestigeLevel() {
+        this.prestigeLevel = SoulbindEnchantment.getPrestigeLevel(itemMeta);
+    }
+
+    private void constructItemWorth() {
+        if (showItemWorth)
+            itemWorth = ItemSettingsConfig.loreWorth
+                    .replace("$worth", ItemWorthCalculator.determineItemWorth(itemStack) + "")
+                    .replace("$currencyName", EconomySettingsConfig.currencyName);
+        else
+            itemWorth = ItemSettingsConfig.loreResale
+                    .replace("$resale", ItemWorthCalculator.determineResaleWorth(itemStack) + "")
+                    .replace("$currencyName", EconomySettingsConfig.currencyName);
+    }
+
+    private void constructItemSource() {
+        itemSource = ItemTagger.getItemSource(itemMeta);
+    }
+
+    private void constructCustomLore() {
+        this.customLore = ItemTagger.getCustomLore(itemMeta);
+    }
+
+    private void constructPotionEffects() {
+        for (ElitePotionEffect elitePotionEffect : ElitePotionEffectContainer.getElitePotionEffectContainer(itemMeta, ItemTagger.continuousPotionEffectKey))
+            potionListLore.add(ChatColorConverter.convert(PotionEffectsConfig.getPotionEffect(
+                    elitePotionEffect.getPotionEffect().getType().getName().toLowerCase() + ".yml").getName()
+                    + ItemSettingsConfig.potionEffectContinuousLore + " " + (elitePotionEffect.getPotionEffect().getAmplifier() + 1)));
+        for (ElitePotionEffect elitePotionEffect : ElitePotionEffectContainer.getElitePotionEffectContainer(itemMeta, ItemTagger.onHitPotionEffectKey))
+            if (elitePotionEffect.getTarget().equals(ElitePotionEffect.Target.SELF))
+                potionListLore.add(ChatColorConverter.convert(PotionEffectsConfig.getPotionEffect(
+                        elitePotionEffect.getPotionEffect().getType().getName().toLowerCase() + ".yml").getName()
+                        + ItemSettingsConfig.potionEffectOnHitSelfLore + " " + (elitePotionEffect.getPotionEffect().getAmplifier() + 1)));
+            else
+                potionListLore.add(ChatColorConverter.convert(PotionEffectsConfig.getPotionEffect(
+                        elitePotionEffect.getPotionEffect().getType().getName().toLowerCase() + ".yml").getName()
+                        + ItemSettingsConfig.potionEffectOnHitTargetLore + " " + (elitePotionEffect.getPotionEffect().getAmplifier() + 1)));
+    }
+
+    private void writeNewLore() {
+        for (String string : ItemSettingsConfig.loreStructure) {
+
+            if (string.contains("$prestigeLevel"))
+                string = string.replace("$prestigeLevel", prestigeLevel + "");
+
+            if (string.contains("$itemLevel"))
+                string = string.replace("$itemLevel", ItemTierFinder.findBattleTier(itemStack) + "");
+
+            if (string.contains("$enchantments")) {
+                for (String entry : vanillaEnchantmentsLore)
+                    lore.add(ChatColorConverter.convert(ItemSettingsConfig.vanillaEnchantmentColor + entry));
+            } else if (string.contains("$eliteEnchantments")) {
+                for (String entry : eliteVanillaEnchantmentsLore)
+                    lore.add(ChatColorConverter.convert(ItemSettingsConfig.eliteEnchantmentColor + ChatColor.stripColor(entry)));
+            } else if (string.contains("$itemSource")) {
+                if (itemSource != null)
+                    lore.add(itemSource);
+            } else if (string.contains("$potionEffect")) {
+                for (String entry : potionListLore)
+                    lore.add(ChatColorConverter.convert(ItemSettingsConfig.potionEffectColor + entry));
+            } else if (string.contains("$customEnchantments")) {
+                for (String entry : customEnchantmentLore)
+                    lore.add(ChatColorConverter.convert(ItemSettingsConfig.customEnchantmentColor + ChatColor.stripColor(entry)));
+            } else if (string.contains("$loreResaleValue")) {
+                lore.add(itemWorth);
+            } else if (string.contains("$customLore")) {
+                for (String entry : customLore)
+                    lore.add(ChatColorConverter.convert(entry));
+            } else if (string.contains("$soulbindInfo")) {
+                lore.add(soulbindInfo);
+                //bypasses in case of conditional formatting
+            } else if (string.contains("$ifPotionEffects")) {
+                if (!potionListLore.isEmpty())
+                    lore.add(string.replace("$ifPotionEffects", ""));
+            } else if (string.contains("$ifEnchantments")) {
+                if (!vanillaEnchantmentsLore.isEmpty())
+                    lore.add(string.replace("$ifEnchantments", ""));
+            } else if (string.contains("$ifLore")) {
+                if (!customLore.isEmpty())
+                    lore.add(string.replace("$ifLore", ""));
+            } else if (string.contains("$ifCustomEnchantments")) {
+                if (!customEnchantments.isEmpty())
+                    lore.add(string.replace("$ifCustomEnchantments", ""));
+            } else
+                lore.add(ChatColorConverter.convert(string));
+
+        }
+    }
+
+}

--- a/src/main/java/com/magmaguy/elitemobs/items/ItemLootShower.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/ItemLootShower.java
@@ -70,7 +70,7 @@ public class ItemLootShower implements Listener {
                             !player.isValid() ||
                             !player.getWorld().equals(item.getWorld()) ||
                             counter > 20 * 4 ||
-                            item.getLocation().distance(player.getLocation()) > 30) {
+                            item.getLocation().distanceSquared(player.getLocation()) > 900) {
                         cancel();
                         pickupable = true;
                         item.setGravity(true);
@@ -133,34 +133,35 @@ public class ItemLootShower implements Listener {
                     return;
                 }
 
-                if (currencyAmount >= 50) {
+                if (currencyAmount >= 1000) {
+                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
+                        dropOneThousand(location);
+                        currencyAmount -= 1000;
+                        return;
+                    }
+                }
+
+                if (currencyAmount >= 500) {
+                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
+                        dropFiveHundred(location);
+                        currencyAmount -= 500;
+                        return;
+                    }
+                }
+
+                if (currencyAmount >= 100) {
+                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
+                        dropOneHundred(location);
+                        currencyAmount -= 100;
+                        return;
+                    }
+
+                } else if (currencyAmount >= 50) {
                     if (ThreadLocalRandom.current().nextDouble() < 0.65) {
                         dropFifty(location);
                         currencyAmount -= 50;
                         return;
                     }
-
-                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
-                        dropTwenty(location);
-                        currencyAmount -= 20;
-                        return;
-                    }
-
-                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
-                        dropTen(location);
-                        currencyAmount -= 10;
-                        return;
-                    }
-
-                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
-                        dropFive(location);
-                        currencyAmount -= 5;
-                        return;
-                    }
-
-                    dropOne(location);
-                    currencyAmount--;
-                    return;
 
                 } else if (currencyAmount >= 20) {
                     if (ThreadLocalRandom.current().nextDouble() < 0.65) {
@@ -169,51 +170,19 @@ public class ItemLootShower implements Listener {
                         return;
                     }
 
-                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
-                        dropTen(location);
-                        currencyAmount -= 10;
-                        return;
-                    }
-
-                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
-                        dropFive(location);
-                        currencyAmount -= 5;
-                        return;
-                    }
-
-                    dropOne(location);
-                    currencyAmount--;
-                    return;
-
                 } else if (currencyAmount >= 10) {
-
                     if (ThreadLocalRandom.current().nextDouble() < 0.65) {
                         dropTen(location);
                         currencyAmount -= 10;
                         return;
                     }
-
-                    if (ThreadLocalRandom.current().nextDouble() < 0.65) {
-                        dropFive(location);
-                        currencyAmount -= 5;
-                        return;
-                    }
-
-                    dropOne(location);
-                    currencyAmount--;
-                    return;
 
                 } else if (currencyAmount >= 5) {
-
                     if (ThreadLocalRandom.current().nextDouble() < 0.65) {
                         dropFive(location);
                         currencyAmount -= 5;
                         return;
                     }
-
-                    dropOne(location);
-                    currencyAmount--;
-                    return;
 
                 } else {
                     dropOne(location);
@@ -236,7 +205,7 @@ public class ItemLootShower implements Listener {
                 0.5,
                 (ThreadLocalRandom.current().nextDouble() - 0.5) / 2));
 
-        SoulbindEnchantment.addEnchantment(currencyItem, this.player);
+        SoulbindEnchantment.addPhysicalDisplay(currencyItem, this.player);
 
         new Coin(value, player, currencyItem);
 
@@ -315,6 +284,45 @@ public class ItemLootShower implements Listener {
         currencyItem.setCustomNameVisible(true);
     }
 
+    private void dropOneHundred(Location location) {
+        Item currencyItem;
+        try {
+            currencyItem = generateCurrencyItem(Material.getMaterial(EconomySettingsConfig.lootShowerMaterial100), location, 100);
+        } catch (Exception ex) {
+            new WarningMessage("Material for EliteMob shower 100 is invalid. Defaulting to diamond.");
+            currencyItem = generateCurrencyItem(Material.DIAMOND, location, 100);
+        }
+
+        currencyItem.setCustomName(ChatColorConverter.convert("&2" + 100 + " " + EconomySettingsConfig.currencyName));
+        currencyItem.setCustomNameVisible(true);
+    }
+
+    private void dropFiveHundred(Location location) {
+        Item currencyItem;
+        try {
+            currencyItem = generateCurrencyItem(Material.getMaterial(EconomySettingsConfig.lootShowerMaterial500), location, 500);
+        } catch (Exception ex) {
+            new WarningMessage("Material for EliteMob shower 500 is invalid. Defaulting to diamond block.");
+            currencyItem = generateCurrencyItem(Material.DIAMOND_BLOCK, location, 500);
+        }
+
+        currencyItem.setCustomName(ChatColorConverter.convert("&2" + 500 + " " + EconomySettingsConfig.currencyName));
+        currencyItem.setCustomNameVisible(true);
+    }
+
+    private void dropOneThousand(Location location) {
+        Item currencyItem;
+        try {
+            currencyItem = generateCurrencyItem(Material.getMaterial(EconomySettingsConfig.lootShowerMaterial1000), location, 1000);
+        } catch (Exception ex) {
+            new WarningMessage("Material for EliteMob shower 1000 is invalid. Defaulting to nether star.");
+            currencyItem = generateCurrencyItem(Material.NETHER_STAR, location, 1000);
+        }
+
+        currencyItem.setCustomName(ChatColorConverter.convert("&2" + 1000 + " " + EconomySettingsConfig.currencyName));
+        currencyItem.setCustomNameVisible(true);
+    }
+
 
     private static final HashMap<Player, Double> playerCurrencyPickup = new HashMap<>();
 
@@ -335,25 +343,25 @@ public class ItemLootShower implements Listener {
                 return;
 
             //if (event.getEntity() instanceof Player) {
-                coinValues.remove(event.getItem().getUniqueId());
+            coinValues.remove(event.getItem().getUniqueId());
             double amountIncremented = coin.value;
             Player player = event.getPlayer();
-                event.getItem().remove();
-                EconomyHandler.addCurrency(player.getUniqueId(), amountIncremented);
-                sendCurrencyNotification(player);
+            event.getItem().remove();
+            EconomyHandler.addCurrency(player.getUniqueId(), amountIncremented);
+            sendCurrencyNotification(player);
 
-                //cache for counting how much coin they're getting over a short amount of time
-                if (playerCurrencyPickup.containsKey(player))
-                    playerCurrencyPickup.put(player, playerCurrencyPickup.get(player) + amountIncremented);
-                else
-                    playerCurrencyPickup.put(player, amountIncremented);
+            //cache for counting how much coin they're getting over a short amount of time
+            if (playerCurrencyPickup.containsKey(player))
+                playerCurrencyPickup.put(player, playerCurrencyPickup.get(player) + amountIncremented);
+            else
+                playerCurrencyPickup.put(player, amountIncremented);
 
-                player.spigot().sendMessage(ChatMessageType.ACTION_BAR,
-                        TextComponent.fromLegacyText(
-                                ChatColorConverter.convert(EconomySettingsConfig.actionBarCurrencyShowerMessage
-                                        .replace("$currency_name", EconomySettingsConfig.currencyName)
-                                        .replace("$amount", Round.twoDecimalPlaces(playerCurrencyPickup.get(player)) + ""))));
-            }
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR,
+                    TextComponent.fromLegacyText(
+                            ChatColorConverter.convert(EconomySettingsConfig.actionBarCurrencyShowerMessage
+                                    .replace("$currency_name", EconomySettingsConfig.currencyName)
+                                    .replace("$amount", Round.twoDecimalPlaces(playerCurrencyPickup.get(player)) + ""))));
+        }
         //}
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/items/ItemTierFinder.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/ItemTierFinder.java
@@ -146,7 +146,7 @@ public class ItemTierFinder {
             case DIAMOND_AXE:
                 return DIAMOND_TIER + mainEnchantment;
             case TRIDENT:
-                return CombatSystem.TRIDENT + mainEnchantment;
+                return CombatSystem.TRIDENT_TIER_LEVEL + mainEnchantment;
             case DIAMOND_BOOTS:
             case DIAMOND_CHESTPLATE:
             case DIAMOND_HELMET:
@@ -232,7 +232,7 @@ public class ItemTierFinder {
             case DIAMOND_AXE:
                 return DIAMOND_TIER + mainEnchantment;
             case TRIDENT:
-                return CombatSystem.TRIDENT + mainEnchantment;
+                return CombatSystem.TRIDENT_TIER_LEVEL + mainEnchantment;
             case IRON_AXE:
             case IRON_SWORD:
                 return IRON_TIER + mainEnchantment;

--- a/src/main/java/com/magmaguy/elitemobs/items/LootTables.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/LootTables.java
@@ -67,9 +67,9 @@ public class LootTables implements Listener {
                         }
                     }.runTaskLater(MetadataHandler.PLUGIN, 20 * 10);
                 }
-                item = generateLoot((int) Math.floor(itemTier), eliteMobEntity);
+                item = generateLoot((int) Math.floor(itemTier), eliteMobEntity, player);
             } else
-                item = generateLoot(eliteMobEntity);
+                item = generateLoot(eliteMobEntity, player);
 
             if (item != null &&
                     item.getItemStack() != null &&
@@ -79,7 +79,7 @@ public class LootTables implements Listener {
                 item.setCustomNameVisible(true);
             }
 
-            SoulbindEnchantment.addEnchantment(item, player);
+            SoulbindEnchantment.addPhysicalDisplay(item, player);
 
             if (item == null) return;
 
@@ -94,7 +94,7 @@ public class LootTables implements Listener {
     private static final boolean limitedItemsExist = CustomItem.getLimitedItem() != null && !CustomItem.getLimitedItem().isEmpty();
     private static final boolean scalableItemsExist = CustomItem.getScalableItems() != null && !CustomItem.getScalableItems().isEmpty();
 
-    private static Item generateLoot(EliteMobEntity eliteMobEntity) {
+    private static Item generateLoot(EliteMobEntity eliteMobEntity, Player player) {
 
         int mobTier = (int) MobTierCalculator.findMobTier(eliteMobEntity);
 
@@ -103,11 +103,11 @@ public class LootTables implements Listener {
          */
         int itemTier = (int) setItemTier(mobTier);
 
-        return generateLoot(itemTier, eliteMobEntity);
+        return generateLoot(itemTier, eliteMobEntity, player);
 
     }
 
-    private static Item generateLoot(int itemTier, EliteMobEntity eliteMobEntity) {
+    private static Item generateLoot(int itemTier, EliteMobEntity eliteMobEntity, Player player) {
 
          /*
         Handle the odds of an item dropping
@@ -137,15 +137,15 @@ public class LootTables implements Listener {
 
         switch (selectedLootSystem) {
             case "procedural":
-                return dropProcedurallyGeneratedItem(itemTier, eliteMobEntity);
+                return dropProcedurallyGeneratedItem(itemTier, eliteMobEntity, player);
             case "weighed":
-                return dropWeighedFixedItem(eliteMobEntity.getLivingEntity().getLocation());
+                return dropWeighedFixedItem(eliteMobEntity.getLivingEntity().getLocation(), player);
             case "fixed":
-                return dropFixedItem(eliteMobEntity, itemTier);
+                return dropFixedItem(eliteMobEntity, itemTier, player);
             case "limited":
-                return dropLimitedItem(eliteMobEntity, itemTier);
+                return dropLimitedItem(eliteMobEntity, itemTier, player);
             case "scalable":
-                return dropScalableItem(eliteMobEntity, itemTier);
+                return dropScalableItem(eliteMobEntity, itemTier, player);
         }
 
         return null;
@@ -180,7 +180,7 @@ public class LootTables implements Listener {
     }
 
 
-    private static Item dropWeighedFixedItem(Location location) {
+    private static Item dropWeighedFixedItem(Location location, Player player) {
 
         double totalWeight = 0;
 
@@ -198,35 +198,37 @@ public class LootTables implements Listener {
             }
         }
 
+        SoulbindEnchantment.addEnchantment(generatedItemStack, player);
+
         return location.getWorld().dropItem(location, generatedItemStack);
 
     }
 
-    private static Item dropProcedurallyGeneratedItem(int tierLevel, EliteMobEntity eliteMobEntity) {
+    private static Item dropProcedurallyGeneratedItem(int tierLevel, EliteMobEntity eliteMobEntity, Player player) {
 
-        ItemStack randomLoot = ItemConstructor.constructItem(tierLevel, eliteMobEntity);
+        ItemStack randomLoot = ItemConstructor.constructItem(tierLevel, eliteMobEntity, player, false);
         return eliteMobEntity.getLivingEntity().getWorld().dropItem(eliteMobEntity.getLivingEntity().getLocation(), randomLoot);
 
     }
 
-    private static Item dropScalableItem(EliteMobEntity eliteMobEntity, int itemTier) {
+    private static Item dropScalableItem(EliteMobEntity eliteMobEntity, int itemTier, Player player) {
 
         return eliteMobEntity.getLivingEntity().getWorld().dropItem(eliteMobEntity.getLivingEntity().getLocation(),
-                ScalableItemConstructor.randomizeScalableItem(itemTier));
+                ScalableItemConstructor.randomizeScalableItem(itemTier, player));
 
     }
 
-    private static Item dropLimitedItem(EliteMobEntity eliteMobEntity, int itemTier) {
+    private static Item dropLimitedItem(EliteMobEntity eliteMobEntity, int itemTier, Player player) {
 
         return eliteMobEntity.getLivingEntity().getWorld().dropItem(eliteMobEntity.getLivingEntity().getLocation(),
-                ScalableItemConstructor.randomizeLimitedItem(itemTier));
+                ScalableItemConstructor.randomizeLimitedItem(itemTier, player));
 
     }
 
-    private static Item dropFixedItem(EliteMobEntity eliteMobEntity, int itemTier) {
+    private static Item dropFixedItem(EliteMobEntity eliteMobEntity, int itemTier, Player player) {
 
         return eliteMobEntity.getLivingEntity().getWorld().dropItem(eliteMobEntity.getLivingEntity().getLocation(),
-                CustomItem.getFixedItems().get(itemTier).get(ThreadLocalRandom.current().nextInt(CustomItem.getFixedItems().get(itemTier).size())).generateDefaultsItemStack());
+                CustomItem.getFixedItems().get(itemTier).get(ThreadLocalRandom.current().nextInt(CustomItem.getFixedItems().get(itemTier).size())).generateDefaultsItemStack(player, false));
 
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/items/ScalableItemConstructor.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/ScalableItemConstructor.java
@@ -4,6 +4,7 @@ import com.magmaguy.elitemobs.config.ItemSettingsConfig;
 import com.magmaguy.elitemobs.items.customitems.CustomItem;
 import com.magmaguy.elitemobs.items.itemconstructor.ItemConstructor;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -13,12 +14,12 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class ScalableItemConstructor {
 
-    public static ItemStack randomizeScalableItem(int itemTier) {
+    public static ItemStack randomizeScalableItem(int itemTier, Player player) {
         CustomItem customItem = CustomItem.getScalableItems().get(ThreadLocalRandom.current().nextInt(CustomItem.getScalableItems().size()));
-        return constructScalableItem(itemTier, customItem);
+        return constructScalableItem(itemTier, customItem, player);
     }
 
-    public static ItemStack constructScalableItem(int itemTier, CustomItem customItem) {
+    public static ItemStack constructScalableItem(int itemTier, CustomItem customItem, Player player) {
         HashMap<Enchantment, Integer> newEnchantmentList = updateDynamicEnchantments(customItem.getEnchantments(), itemTier);
         return ItemConstructor.constructItem(
                 customItem.getName(),
@@ -27,7 +28,9 @@ public class ScalableItemConstructor {
                 customItem.getCustomEnchantments(),
                 customItem.getPotionEffects(),
                 customItem.getLore(),
-                null
+                null,
+                player,
+                false
         );
     }
 
@@ -96,7 +99,7 @@ public class ScalableItemConstructor {
     entry, and every other entry is just a nerfed version of that item. Basically an easy way to limit an item in a
     predictable way.
      */
-    public static ItemStack randomizeLimitedItem(int itemTier) {
+    public static ItemStack randomizeLimitedItem(int itemTier, Player player) {
 
         List<CustomItem> localLootList = new ArrayList<>();
 
@@ -107,11 +110,11 @@ public class ScalableItemConstructor {
 
         CustomItem customItem = localLootList.get(ThreadLocalRandom.current().nextInt(localLootList.size()));
 
-        return constructLimitedItem(itemTier, customItem);
+        return constructLimitedItem(itemTier, customItem, player);
 
     }
 
-    public static ItemStack constructLimitedItem(int itemTier, CustomItem customItem) {
+    public static ItemStack constructLimitedItem(int itemTier, CustomItem customItem, Player player) {
 
         HashMap<Enchantment, Integer> newEnchantmentList = updateLimitedEnchantments(customItem.getEnchantments(), itemTier);
 
@@ -122,7 +125,9 @@ public class ScalableItemConstructor {
                 customItem.getCustomEnchantments(),
                 customItem.getPotionEffects(),
                 customItem.getLore(),
-                null
+                null,
+                player,
+                false
         );
 
     }

--- a/src/main/java/com/magmaguy/elitemobs/items/ShareItem.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/ShareItem.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -33,7 +34,7 @@ public class ShareItem {
         String stringList = itemStack.getItemMeta().getDisplayName();
         if (itemStack.getItemMeta().hasLore())
             for (String loreString : itemStack.getItemMeta().getLore())
-                stringList += "\n" + loreString;
+                stringList += "\n" + ChatColor.DARK_PURPLE + ChatColor.ITALIC + loreString;
         textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(stringList).create()));
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CriticalStrikesEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CriticalStrikesEnchantment.java
@@ -12,7 +12,7 @@ public class CriticalStrikesEnchantment extends CustomEnchantment {
     public static String key = "critical_strikes";
 
     public CriticalStrikesEnchantment() {
-        super(key);
+        super(key, true);
     }
 
     public static void criticalStrikePopupMessage(Entity entity, Vector offset) {

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CustomEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CustomEnchantment.java
@@ -3,37 +3,33 @@ package com.magmaguy.elitemobs.items.customenchantments;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfig;
 import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfigFields;
-import com.magmaguy.elitemobs.config.enchantments.premade.CriticalStrikesConfig;
 import com.magmaguy.elitemobs.items.ItemTagger;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 
 public abstract class CustomEnchantment {
 
-    /*
-    Store key + custom enchantment
-     */
-    private static HashMap<String, CustomEnchantment> customEnchantments = new HashMap<>();
+    private static final ArrayList<CustomEnchantment> customEnchantments = new ArrayList<>();
 
-    public static HashMap<String, CustomEnchantment> getCustomEnchantments() {
+    public static ArrayList<CustomEnchantment> getCustomEnchantments() {
         return customEnchantments;
     }
 
-    public static CustomEnchantment getCustomEnchantment(String key) {
-        return customEnchantments.get(key);
-    }
+    private final String key;
+    private final boolean dynamic;
+    private final EnchantmentsConfigFields enchantmentsConfigFields;
+    private final Enchantment originalEnchantment = null;
 
-    private String key;
-    private EnchantmentsConfigFields enchantmentsConfigFields;
-
-    public CustomEnchantment(String key) {
+    public CustomEnchantment(String key, boolean dynamic) {
         this.key = key;
+        this.dynamic = dynamic;
         this.enchantmentsConfigFields = EnchantmentsConfig.getEnchantment(key + ".yml");
-        customEnchantments.put(key, this);
+        customEnchantments.add(this);
     }
 
     public String getKey() {
@@ -47,7 +43,10 @@ public abstract class CustomEnchantment {
     public static void initializeCustomEnchantments() {
         new FlamethrowerEnchantment();
         new HunterEnchantment();
-        new CriticalStrikesConfig();
+        new CriticalStrikesEnchantment();
+        new DrillingEnchantment();
+        new IceBreakerEnchantment();
+        new MeteorShowerEnchantment();
     }
 
     /*

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/DrillingEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/DrillingEnchantment.java
@@ -24,7 +24,7 @@ public class DrillingEnchantment extends CustomEnchantment implements Listener {
     public static String key = "drilling";
 
     public DrillingEnchantment() {
-        super(key);
+        super(key, false);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/FlamethrowerEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/FlamethrowerEnchantment.java
@@ -28,7 +28,7 @@ public class FlamethrowerEnchantment extends CustomEnchantment {
     public static String key = "flamethrower";
 
     public FlamethrowerEnchantment() {
-        super(key);
+        super(key, false);
     }
 
     private static final ArrayList<Player> playersUsingFlamethrower = new ArrayList<>();

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/HunterEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/HunterEnchantment.java
@@ -1,7 +1,6 @@
 package com.magmaguy.elitemobs.items.customenchantments;
 
 import com.magmaguy.elitemobs.playerdata.ElitePlayerInventory;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -11,10 +10,8 @@ public class HunterEnchantment extends CustomEnchantment {
     public static String key = "hunter";
 
     public HunterEnchantment() {
-        super(key);
+        super(key, false);
     }
-
-    private static final int range = Bukkit.getServer().getViewDistance() * 16;
 
     public static double getHuntingGearBonus(ArrayList<Player> players) {
         double huntingGearChanceAdder = 0;

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/IceBreakerEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/IceBreakerEnchantment.java
@@ -15,7 +15,7 @@ public class IceBreakerEnchantment extends CustomEnchantment {
     public static String key = "ice_breaker";
 
     public IceBreakerEnchantment() {
-        super(key);
+        super(key, false);
     }
 
     private static boolean isValidBlock(Block block) {

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/MeteorShowerEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/MeteorShowerEnchantment.java
@@ -21,7 +21,7 @@ public class MeteorShowerEnchantment extends CustomEnchantment {
     public static String key = "meteor_shower";
 
     public MeteorShowerEnchantment() {
-        super(key);
+        super(key, false);
     }
 
     public static void doMeteorShower(Player player) {

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/SoulbindEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/SoulbindEnchantment.java
@@ -5,7 +5,9 @@ import com.magmaguy.elitemobs.EntityTracker;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.adventurersguild.GuildRank;
 import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfig;
+import com.magmaguy.elitemobs.items.EliteItemLore;
 import com.magmaguy.elitemobs.utils.VisualArmorStand;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.ArmorStand;
@@ -21,27 +23,39 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.UUID;
 
 public class SoulbindEnchantment extends CustomEnchantment {
 
     public static String key = "soulbind";
 
     public SoulbindEnchantment() {
-        super(key);
+        super(key, true);
     }
 
-    public static void addEnchantment(Item item, Player player) {
+    public static void addEnchantment(ItemStack itemStack, Player player) {
         if (!EnchantmentsConfig.getEnchantment(SoulbindEnchantment.key + ".yml").isEnabled()) return;
-        if (item == null) return;
-        addEnchantment(item.getItemStack(), player);
+        if (itemStack == null || player == null) return;
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        itemMeta.getPersistentDataContainer().set(SOULBIND_KEY, PersistentDataType.STRING, player.getUniqueId().toString());
+        setPrestigeLevel(itemMeta, GuildRank.getGuildPrestigeRank(player));
+        itemStack.setItemMeta(itemMeta);
+        //todo: this might not be the best way of doing this
+    }
+
+    public static void removeEnchantment(ItemStack itemStack) {
+        if (itemStack == null) return;
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        itemMeta.getPersistentDataContainer().remove(SOULBIND_KEY);
+        itemStack.setItemMeta(itemMeta);
+        //update item lore display
+        new EliteItemLore(itemStack, false);
+    }
+
+    public static void addPhysicalDisplay(Item item, Player player) {
         new BukkitRunnable() {
             @Override
             public void run() {
-                if (!item.isValid())
-                    return;
-
                 ArmorStand soulboundPlayer = VisualArmorStand.VisualArmorStand(item.getLocation().clone().add(new Vector(0, -50, 0)), ChatColorConverter.convert(
                         EnchantmentsConfig.getEnchantment("soulbind.yml")
                                 .getFileConfiguration().getString("hologramString").replace("$player", player.getDisplayName())));
@@ -65,32 +79,10 @@ public class SoulbindEnchantment extends CustomEnchantment {
                 }.runTaskTimer(MetadataHandler.PLUGIN, 1, 1);
             }
         }.runTaskLater(MetadataHandler.PLUGIN, 20 * 3);
-
     }
 
-    private static final NamespacedKey namespacedKey = new NamespacedKey(MetadataHandler.PLUGIN, key);
-
-    private static void addEnchantment(ItemStack itemStack, Player player) {
-        ItemMeta itemMeta = itemStack.getItemMeta();
-        //for legacy reasons, prestige 0 gets no prestige tier id
-        if (GuildRank.getGuildPrestigeRank(player) == 0)
-            itemMeta.getPersistentDataContainer().set(namespacedKey, PersistentDataType.STRING, player.getUniqueId().toString());
-        else
-            itemMeta.getPersistentDataContainer().set(namespacedKey, PersistentDataType.STRING, player.getUniqueId().toString() + GuildRank.getGuildPrestigeRank(player));
-        itemStack.setItemMeta(itemMeta);
-        List<String> lore = itemStack.getItemMeta().getLore();
-        if (lore == null)
-            lore = new ArrayList<>();
-        lore.add(
-                ChatColorConverter.convert(
-                        EnchantmentsConfig.getEnchantment("soulbind.yml")
-                                .getFileConfiguration().getString("loreString").replace("$player", player.getDisplayName())));
-        if (GuildRank.getGuildPrestigeRank(player) > 0)
-            lore.add(ChatColorConverter.convert("Prestige " + GuildRank.getGuildPrestigeRank(player)));
-
-        itemMeta.setLore(lore);
-        itemStack.setItemMeta(itemMeta);
-    }
+    private static final NamespacedKey SOULBIND_KEY = new NamespacedKey(MetadataHandler.PLUGIN, key);
+    private static final NamespacedKey PRESTIGE_KEY = new NamespacedKey(MetadataHandler.PLUGIN, "prestige");
 
     public static boolean isValidSoulbindUser(ItemMeta itemMeta, Player player) {
         if (itemMeta == null)
@@ -99,12 +91,41 @@ public class SoulbindEnchantment extends CustomEnchantment {
         //if (GuildRank.getGuildPrestigeRank(player) == 0)
         //    if (itemMeta.getCustomTagContainer().hasCustomTag(namespacedKey, ItemTagType.STRING))
         //        return itemMeta.getCustomTagContainer().getCustomTag(new NamespacedKey(MetadataHandler.PLUGIN, key), ItemTagType.STRING).equals(player.getUniqueId().toString());
-        if (!itemMeta.getPersistentDataContainer().has(namespacedKey, PersistentDataType.STRING))
+        if (!itemMeta.getPersistentDataContainer().has(SOULBIND_KEY, PersistentDataType.STRING))
             return true;
         if (GuildRank.getGuildPrestigeRank(player) == 0)
             return itemMeta.getPersistentDataContainer().get(new NamespacedKey(MetadataHandler.PLUGIN, key), PersistentDataType.STRING).equals(player.getUniqueId().toString());
+            //this is kept for legacy reasons, old items just appended the prestige tier at the end of the uuid
+        else if ((itemMeta.getPersistentDataContainer().get(new NamespacedKey(MetadataHandler.PLUGIN, key), PersistentDataType.STRING)).equals(player.getUniqueId().toString() + GuildRank.getGuildPrestigeRank(player)))
+            return true;
         else
-            return (itemMeta.getPersistentDataContainer().get(new NamespacedKey(MetadataHandler.PLUGIN, key), PersistentDataType.STRING)).equals(player.getUniqueId().toString() + GuildRank.getGuildPrestigeRank(player));
+            return getPrestigeLevel(itemMeta) == GuildRank.getGuildPrestigeRank(player);
+    }
+
+    public static Player getSoulboundPlayer(ItemMeta itemMeta) {
+        if (!itemMeta.getPersistentDataContainer().has(SOULBIND_KEY, PersistentDataType.STRING))
+            return null;
+        try {
+            UUID uuid = UUID.fromString(itemMeta.getPersistentDataContainer().get(new NamespacedKey(MetadataHandler.PLUGIN, key), PersistentDataType.STRING));
+            return Bukkit.getPlayer(uuid);
+        } catch (Exception ex) {
+
+        }
+        return null;
+        //return Bukkit.getPlayer(UUID.fromString(itemMeta.getPersistentDataContainer().get(new NamespacedKey(MetadataHandler.PLUGIN, key), PersistentDataType.STRING)));
+    }
+
+    private static void setPrestigeLevel(ItemMeta itemMeta, int prestigeLevel) {
+        itemMeta.getPersistentDataContainer().set(PRESTIGE_KEY, PersistentDataType.INTEGER, prestigeLevel);
+    }
+
+    public static int getPrestigeLevel(ItemMeta itemMeta) {
+        if (!itemMeta.getPersistentDataContainer().has(SOULBIND_KEY, PersistentDataType.STRING))
+            return 0;
+        int prestige = 0;
+        if (itemMeta.getPersistentDataContainer().get(PRESTIGE_KEY, PersistentDataType.INTEGER) != null)
+            prestige = itemMeta.getPersistentDataContainer().get(PRESTIGE_KEY, PersistentDataType.INTEGER);
+        return prestige;
     }
 
     public static class SoulbindEnchantmentEvents implements Listener {

--- a/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/ItemConstructor.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/ItemConstructor.java
@@ -1,11 +1,14 @@
 package com.magmaguy.elitemobs.items.itemconstructor;
 
 import com.magmaguy.elitemobs.config.ItemSettingsConfig;
+import com.magmaguy.elitemobs.items.EliteItemLore;
 import com.magmaguy.elitemobs.items.ItemTagger;
+import com.magmaguy.elitemobs.items.customenchantments.SoulbindEnchantment;
 import com.magmaguy.elitemobs.mobconstructor.EliteMobEntity;
 import com.magmaguy.elitemobs.utils.ItemStackGenerator;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -21,7 +24,9 @@ public class ItemConstructor {
                                           HashMap<String, Integer> customEnchantments,
                                           List<String> potionEffects,
                                           List<String> lore,
-                                          EliteMobEntity eliteMobEntity) {
+                                          EliteMobEntity eliteMobEntity,
+                                          Player player,
+                                          boolean showItemWorth) {
 
         ItemStack itemStack;
         ItemMeta itemMeta;
@@ -69,13 +74,28 @@ public class ItemConstructor {
 
         ItemTagger.registerEliteItem(itemStack);
 
+        /*
+        Add soulbind if applicable
+         */
+        SoulbindEnchantment.addEnchantment(itemStack, player);
+
+        /*
+        Register item source for lore redraw
+         */
+        ItemTagger.registerItemSource(eliteMobEntity, itemStack);
+
+        /*
+        Update lore
+         */
+        new EliteItemLore(itemStack, showItemWorth);
+
         return itemStack;
     }
 
     /*
     For procedurally generated items
      */
-    public static ItemStack constructItem(double itemTier, EliteMobEntity killedMob) {
+    public static ItemStack constructItem(double itemTier, EliteMobEntity killedMob, Player player, boolean showItemWorth) {
 
         ItemStack itemStack;
         ItemMeta itemMeta;
@@ -126,6 +146,21 @@ public class ItemConstructor {
         ItemQualityColorizer.dropQualityColorizer(itemStack);
 
         ItemTagger.registerEliteItem(itemStack);
+
+        /*
+        Add soulbind if applicable
+         */
+        SoulbindEnchantment.addEnchantment(itemStack, player);
+
+        /*
+        Register item source for lore redraw
+         */
+        ItemTagger.registerItemSource(killedMob, itemStack);
+
+        /*
+        Update lore
+         */
+        new EliteItemLore(itemStack, showItemWorth);
 
         return itemStack;
 

--- a/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/LoreGenerator.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/LoreGenerator.java
@@ -221,8 +221,10 @@ public class LoreGenerator {
 
     }
 
-    private static String itemResaleWorth(Material
-                                                  material, HashMap<Enchantment, Integer> enchantmentMap, HashMap<String, Integer> customEnchantments, List<String> potionList) {
+    private static String itemResaleWorth(Material material,
+                                          HashMap<Enchantment, Integer> enchantmentMap,
+                                          HashMap<String, Integer> customEnchantments,
+                                          List<String> potionList) {
 
         return ItemSettingsConfig.loreResale
                 .replace("$resale", ItemWorthCalculator.determineResaleWorth(material, enchantmentMap, potionList, customEnchantments) + "")

--- a/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/MaterialGenerator.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/MaterialGenerator.java
@@ -28,7 +28,7 @@ public class MaterialGenerator {
         if (localValidMaterials.isEmpty()) initializeValidProceduralMaterials();
 
 
-        if (itemTier < CombatSystem.TRIDENT)
+        if (itemTier < CombatSystem.TRIDENT_TIER_LEVEL)
             localValidMaterials.remove(TRIDENT);
 
         if (VersionChecker.currentVersionIsUnder(16, 0) && itemTier < CombatSystem.NETHERITE_TIER_LEVEL)

--- a/src/main/java/com/magmaguy/elitemobs/ondeathcommands/OnDeathCommands.java
+++ b/src/main/java/com/magmaguy/elitemobs/ondeathcommands/OnDeathCommands.java
@@ -23,6 +23,14 @@ public class OnDeathCommands implements Listener {
                 string = string.replace("$level", event.getEliteMobEntity().getLevel() + "");
             if (string.contains("$name"))
                 string = string.replace("$name", event.getEliteMobEntity().getName());
+            if (string.contains("$locationWorldName"))
+                string = string.replace("$locationWorldName", event.getEliteMobEntity().getLivingEntity().getLocation().getWorld().getName());
+            if (string.contains("$locationX"))
+                string = string.replace("$locationX", event.getEliteMobEntity().getLivingEntity().getLocation().getX() + "");
+            if (string.contains("$locationY"))
+                string = string.replace("$locationY", event.getEliteMobEntity().getLivingEntity().getLocation().getY() + "");
+            if (string.contains("$locationZ"))
+                string = string.replace("$locationZ", event.getEliteMobEntity().getLivingEntity().getLocation().getZ() + "");
             if (string.contains("$players")) {
                 if (event.getEliteMobEntity().hasDamagers())
                     for (Player player : event.getEliteMobEntity().getDamagers().keySet())

--- a/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerData.java
+++ b/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerData.java
@@ -3,7 +3,6 @@ package com.magmaguy.elitemobs.playerdata;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.quests.EliteQuest;
 import com.magmaguy.elitemobs.quests.PlayerQuests;
-import com.magmaguy.elitemobs.utils.DebugMessage;
 import com.magmaguy.elitemobs.utils.WarningMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -447,7 +446,6 @@ public class PlayerData {
             statement.close();
             getConnection().commit();
             getConnection().close();
-            new DebugMessage("Created new database entry for player " + Bukkit.getPlayer(uuid).getDisplayName());
         } catch (Exception e) {
             new WarningMessage("Failed to generate an entry!");
             closeConnection();

--- a/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerItem.java
+++ b/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerItem.java
@@ -40,6 +40,16 @@ public class PlayerItem {
     private double critChance = 0;
     private double hunterChance = 0;
 
+
+    /**
+     * Stores an instance of the custom EliteMobs values of what a player is wearing. This is used to reduce the amount
+     * of checks done by EliteMobs during combat and for passive potion effect applications. It should (largely) only update
+     * when necessary.
+     *
+     * @param itemStack     ItemStack in the equipment slot. Does not update.
+     * @param equipmentSlot Player's equipment slot. This is used to quickly access weapons and armor for the combat system. Updates when the ItemStack changes.
+     * @param player        Player associated to the gear. Does not update.
+     */
     public PlayerItem(ItemStack itemStack, EquipmentSlot equipmentSlot, Player player) {
         this.equipmentSlot = equipmentSlot; //equipment slot never updates
         this.player = player;
@@ -81,8 +91,9 @@ public class PlayerItem {
             this.damageArthropodsLevel = ItemTagger.getEnchantment(itemStack.getItemMeta(), Enchantment.DAMAGE_ARTHROPODS.getKey());
             this.damageUndeadLevel = ItemTagger.getEnchantment(itemStack.getItemMeta(), Enchantment.DAMAGE_UNDEAD.getKey());
             this.critChance = ItemTagger.getEnchantment(itemStack.getItemMeta(), new NamespacedKey(MetadataHandler.PLUGIN, CriticalStrikesEnchantment.key)) / 10D;
-        } else if (!equipmentSlot.equals(EquipmentSlot.OFFHAND))
-            this.hunterChance = ItemTagger.getEnchantment(itemStack.getItemMeta(), new NamespacedKey(MetadataHandler.PLUGIN, HunterEnchantment.key)) * EnchantmentsConfig.getEnchantment("hunter.yml").getFileConfiguration().getDouble("hunterSpawnBonus");
+        }
+
+        this.hunterChance = ItemTagger.getEnchantment(itemStack.getItemMeta(), new NamespacedKey(MetadataHandler.PLUGIN, HunterEnchantment.key)) * EnchantmentsConfig.getEnchantment("hunter.yml").getFileConfiguration().getDouble("hunterSpawnBonus");
 
         return true;
 

--- a/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerStatsTracker.java
+++ b/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerStatsTracker.java
@@ -1,9 +1,11 @@
 package com.magmaguy.elitemobs.playerdata;
 
+import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.api.EliteMobDeathEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class PlayerStatsTracker implements Listener {
 
@@ -16,10 +18,15 @@ public class PlayerStatsTracker implements Listener {
     public void onEliteDeath(EliteMobDeathEvent event) {
         if (event.getEliteMobEntity().getTriggeredAntiExploit()) return;
         if (event.getEliteMobEntity().getDamagers().isEmpty()) return;
-        for (Player player : event.getEliteMobEntity().getDamagers().keySet()) {
-            PlayerData.incrementKills(player.getUniqueId());
-            PlayerData.setHighestLevelKilled(player.getUniqueId(), event.getEliteMobEntity().getLevel());
-            PlayerData.incrementScore(player.getUniqueId(), event.getEliteMobEntity().getLevel());
-        }
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : event.getEliteMobEntity().getDamagers().keySet()) {
+                    PlayerData.incrementKills(player.getUniqueId());
+                    PlayerData.setHighestLevelKilled(player.getUniqueId(), event.getEliteMobEntity().getLevel());
+                    PlayerData.incrementScore(player.getUniqueId(), event.getEliteMobEntity().getLevel());
+                }
+            }
+        }.runTaskAsynchronously(MetadataHandler.PLUGIN);
     }
 }

--- a/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerStatusScreen.java
+++ b/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerStatusScreen.java
@@ -151,7 +151,7 @@ public class PlayerStatusScreen implements Listener {
         for (int i = 0; i < 13; i++) {
             TextComponent line = new TextComponent(PlayerStatusMenuConfig.statsTextLines[i]
                     .replace("$money", EconomyHandler.checkCurrency(targetPlayer.getUniqueId()) + "")
-                    .replace("$guildtier", AdventurersGuildConfig.getShortenedRankName(GuildRank.getGuildPrestigeRank(targetPlayer), GuildRank.getActiveGuildRank(targetPlayer)))
+                    .replace("$guildtier", ChatColor.stripColor(AdventurersGuildConfig.getShortenedRankName(GuildRank.getGuildPrestigeRank(targetPlayer), GuildRank.getActiveGuildRank(targetPlayer))))
                     .replace("$kills", PlayerData.getKills(targetPlayer.getUniqueId()) + "")
                     .replace("$highestkill", PlayerData.getHighestLevelKilled(targetPlayer.getUniqueId()) + "")
                     .replace("$deaths", PlayerData.getDeaths(targetPlayer.getUniqueId()) + "")
@@ -437,13 +437,14 @@ public class PlayerStatusScreen implements Listener {
         ArrayList<TextComponent> textComponents = new ArrayList<>();
         int counter = 0;
 
-        for (EliteQuest eliteQuest : PlayerQuests.getData(targetPlayer).quests) {
-            TextComponent quest = new TextComponent(ChatColor.BLACK + ChatColor.stripColor(eliteQuest.getQuestStatus()) + " \n");
-            quest.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/elitemobs quest cancel " + eliteQuest.getUuid()));
-            setHoverText(quest, PlayerStatusMenuConfig.onQuestTrackHover);
-            textComponents.add(quest);
-            counter++;
-        }
+        if (PlayerQuests.getData(targetPlayer).quests != null)
+            for (EliteQuest eliteQuest : PlayerQuests.getData(targetPlayer).quests) {
+                TextComponent quest = new TextComponent(ChatColor.BLACK + ChatColor.stripColor(eliteQuest.getQuestStatus()) + " \n");
+                quest.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/elitemobs quest cancel " + eliteQuest.getUuid()));
+                setHoverText(quest, PlayerStatusMenuConfig.onQuestTrackHover);
+                textComponents.add(quest);
+                counter++;
+            }
 
         if (counter == 0) {
             TextComponent[] textComponent = new TextComponent[1];

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -9,3 +9,118 @@ If you need support with this plugin, you can reach me at my discord support cha
 For all things EliteMobs related, you can go to my website to find all resources I've made available, such as the github page, the wiki, the custom loot maker, so on.
 
 Hope you enjoy! If you do, leave rating on the resource page and / or buy me a coffee ! (paypal links can be found in the spigot resource page)
+
+
+# Dev notes:
+
+## API
+
+EliteMobs has a few basic APIs to interface with in the `com.magmaguy.elitemobs.api` package. Here's the breakdown:
+
+### DamageEliteMob
+
+Used for applying custom damage to Elite Mobs. Uses:
+- Bypass EliteMobs' custom damage system for a specific damage event
+- Apply an automatically recommended custom amount of damage which varies based on the tier of the boss.
+
+*Note:* the variable damage takes the elite's tier into account and deals more damage to higher tiers. It does not take the health multiplier into account for custom bosses for balance reasons.
+
+### EliteMobDamagedByEliteMobEvent
+
+Used for listening to moments when one Elite damages another Elite. Uses:
+- Same as Bukkit's EntityDamagedByEntity event but for elites specifically
+- Cancelling it might not work. Report if it doesn't.
+
+### EliteMobDamagedByPlayerAntiExploit
+Used for listening to events which trigger an antiexploit **check** - doesn't necessarily mean that it detected an exploit. Uses:
+- Same as Bukkit's EntityDamagedByEntity event but for elites specifically
+- Can be cancelled
+
+### EliteMobDamagedByPlayerEvent:
+Used for listening to moments when a player damages an Elite. Uses:
+
+- Same as Bukkit's EntityDamagedByEntity event but for players damaging elites specifically
+- ***Important:*** can't be cancelled as it only fires after applying the damage //todo: fix this
+
+### EliteMobDamagedEvent:
+Used for listening to moments when an elite is damaged in general. Uses:
+
+- Same as Bukkit's EntityDamageEvent
+- ***Important*** Cancelling this event might not 100% work, report if it doesn't
+
+### EliteMobDeathEvent:
+Used to listening to moments when an elite is killed. Uses:
+
+- Same as Bukkit's EntityDeathEvent.
+
+### EliteMobEnterCombatEvent:
+Used for listening to moments when an elite enters combat against a player. Uses:
+
+- Get the target (player only) of the Elite
+- Get the elite which entered in combat
+
+#### EliteMobExitCombatEvent:
+Used for listening to moments when an elite leaves combat against a player. Uses:
+
+- Get the elite which just let combat.
+
+### EliteMobsItemDetector:
+Used for detecting whether an ItemStack is an EliteMobs ItemStack (like a custom item or a procedurally generated item). Uses:
+
+- Detect if an ItemStack is an EliteMobs custom or dynamic item.
+
+### EliteMobSpawnEvent:
+Used for detecting when an Elite spawns. USes:
+
+- Detect when an Elite spawns
+- Detect which Elite spawned
+
+### EliteMobTargetPlayerEvent:
+Used for detecting when an Elite has targetted a player. Uses:
+
+- Detect when an Elite targets a player.
+- Cancel an Elite's detection of a player.
+
+### GenericAntiExploitEvent
+
+Used for listening to moments when the antiexploit runs a check but no players damaged it. Uses:
+
+- Detect when the antiexploit is doing a non-player based exploit check
+- Cancel an antiexploit check
+
+### PlayerDamagedByEliteMobEvent
+
+Used for listening to moments when players are damaged by an Elite. Uses:
+
+- Same as Bukkit's EntityDamageEvent
+
+---
+
+
+## To add new item enchantments:
+1) Add new enchantment class to the `com.magmaguy.elitemobs.config.enchantments.premade` **extending** `EnchantmentsConfigFields` to initialize create its config file (naming convention: [EnchantmentName]Config)
+2) Initialize enchantment in `com.magmaguy.elitemobs.items.customenchantments.CustomEnchantment` to initialize the config file
+3) Add enchantment class to `com.magmaguy.elitemobs.items.customenchantments` **extending** `CustomEnchantment` to write the logic for the enchantment (naming convention [EnchantmentName]Enchantment)
+4) Add a public static String called "key" to register using the ItemTagger class for persistent enchantment tracking
+5) Add an entry to the parseEnchantments() method in `com.magmaguy.elitemobs.items.customitems.CustomItem` so custom items detect it correctly
+6) (Alternative) Add an entry to `generateCustomEnchantments()` method in `com.magmaguy.elitemobs.items.itemconstructor.EnchantmentGenerator` if the enchantment should appear in procedurally generated items
+
+Note:
+- Don't forget to register events in `com.magmaguy.elitemobs.EventsRegistrer` if the part with logic in it requires events.
+- Don't forget to use the damage bypass if the power is supposed to deal custom damage. Damage dealt by the player to an elite can be overwritten in `com.magmaguy.elitemobs.combatsystem.CombatSystem` through the static "bypass" boolean field - it makes the next damage dealt to the elite use the raw damage value. For correctly assigning damage, use Bukkit's `Damageable#damage(double amount, Entity source)` and assign the source to your player.
+
+## To add new powers to elites:
+
+to be documented
+
+## To add new events:
+
+to be documented
+
+## To add new default NPCs:
+
+to be documented
+
+## To add new mob types:
+
+to be documented

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EliteMobs
-version: 7.2.0
+version: 7.2.1
 author: MagmaGuy
 main: com.magmaguy.elitemobs.EliteMobs
 api-version: 1.14


### PR DESCRIPTION
- [New] Item lore can now be updated as item stats change
- [New] Massive changes to the way items are displayed
- [New] Added /em unbind - removes soulbind from items
- [New] Added /em updateitem - manually updates an item's lore
- [New] Added prestigeNameOnItems to ItemSettings.yml for customizing the name of the prestige system on items
- [New] Added $locationWorldName $locationX $locationY $locationZ placeholders to elite on death commands
- [New] Added optional system that prevents players from enchanting elite items through vanilla Minecraftr means
- [New] Elite items enchanted by players new correctly update with the new enchantments
- [New] Added 100, 500 and 1000 coins to the coins system
- [Change] Hunter enchantment now applies for main hand and offhand items
- [Change] Prestige price / bonus money increased from 0.5 to 5.0 to combat the banking strategy
- [Major fix] Fixed documentation issue where followRange was documented as followDistance, changed EliteMobs to use followDistance instead
- [Fix] Player /em screens now show guild ranks without color codes to prevent readability issues
- [Fix] Fixed combat exit triggers
- [Fix] Fixed /em bug related to quests
- [Fix] /em gettier [tierlevel] now actually gives items of the correct tier for tiers 8 and above
- [Fix] Fixed performance issues with the coin system

Signed-off-by: MagmaGuy <tiagoarnaut@gmail.com>