### PR TITLE
Version 7.2.3

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.magmaguy</groupId>
     <artifactId>EliteMobs</artifactId>
-    <version>7.2.2</version>
+    <version>7.2.3</version>
     <build>
         <defaultGoal>clean resources:resources package</defaultGoal>
         <finalName>${project.artifactId}</finalName>
@@ -101,6 +101,12 @@
                     <groupId>org.yaml</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
@@ -247,7 +253,7 @@
         <dependency>
             <groupId>LibsDisguises</groupId>
             <artifactId>LibsDisguises</artifactId>
-            <version>10.0.15</version>
+            <version>10.0.18</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -261,10 +267,6 @@
                 <exclusion>
                     <artifactId>ProtocolLib</artifactId>
                     <groupId>com.comphenix.protocol</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>spigot</artifactId>
-                    <groupId>org.spigotmc</groupId>
                 </exclusion>
                 <exclusion>
                     <artifactId>bungeecord-chat</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.magmaguy</groupId>
     <artifactId>EliteMobs</artifactId>
-    <version>7.2.2</version>
+    <version>7.2.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -92,6 +92,7 @@
         <repository>
             <id>md_5-public</id>
             <url>http://repo.md-5.net/content/groups/public/</url>
+            <!--<url>file:C:\Users\Tiago\Documents\MineCraftProjects\EliteMobs\LibsDisguises.jar</url>-->
         </repository>
 
     </repositories>
@@ -101,6 +102,14 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.3-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- !!!Lib's Disguises currently requires this due to a Maven bug, remove when possible!!!-->
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.16.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -150,7 +159,7 @@
         <dependency>
             <groupId>LibsDisguises</groupId>
             <artifactId>LibsDisguises</artifactId>
-            <version>10.0.15</version>
+            <version>10.0.18</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/magmaguy/elitemobs/EntityTracker.java
+++ b/src/main/java/com/magmaguy/elitemobs/EntityTracker.java
@@ -78,7 +78,7 @@ public class EntityTracker implements Listener {
      * @param eliteMobEntity unregisters this entity from the plugin
      */
     public static void unregisterEliteMob(EliteMobEntity eliteMobEntity) {
-        eliteMobs.remove(eliteMobEntity);
+        eliteMobs.remove(eliteMobEntity.getLivingEntity().getUniqueId());
         cullablePluginEntities.remove(eliteMobEntity.getLivingEntity());
         eliteMobEntity.getLivingEntity().removeMetadata(MetadataHandler.ELITE_MOB_METADATA, MetadataHandler.PLUGIN);
     }

--- a/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
+++ b/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
@@ -269,6 +269,8 @@ public class EventsRegistrer {
 
         //Initialize items from custom events
         pluginManager.registerEvents(new FlamethrowerEnchantment.FlamethrowerEnchantmentEvents(), plugin);
+        //if (EnchantmentsConfig.getEnchantment(SummonMerchantEnchantment.key + ".yml").isEnabled())
+        pluginManager.registerEvents(new SummonMerchantEnchantment.SummonMerchantEvents(), plugin);
         pluginManager.registerEvents(new MeteorShowerEnchantment.MeteorShowerEvents(), plugin);
         pluginManager.registerEvents(new DrillingEnchantment(), plugin);
         pluginManager.registerEvents(new IceBreakerEnchantment.IceBreakerEnchantmentEvent(), plugin);

--- a/src/main/java/com/magmaguy/elitemobs/commands/CommandHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/CommandHandler.java
@@ -106,7 +106,8 @@ public class CommandHandler implements CommandExecutor {
                     permission.equals(CURRENCY_PAY) ||
                     permission.equals(CURRENCY_WALLET) ||
                     permission.equals(ADVENTURERS_GUILD) ||
-                    permission.equals(QUEST))
+                    permission.equals(QUEST) ||
+                    permission.equals("elitemobs.guild.npc"))
                 return true;
             else if (commandSender.isOp())
                 return true;

--- a/src/main/java/com/magmaguy/elitemobs/commands/admin/npc/NPCCommands.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/admin/npc/NPCCommands.java
@@ -3,6 +3,7 @@ package com.magmaguy.elitemobs.commands.admin.npc;
 import com.magmaguy.elitemobs.commands.CommandHandler;
 import com.magmaguy.elitemobs.config.npcs.NPCsConfig;
 import com.magmaguy.elitemobs.config.npcs.NPCsConfigFields;
+import com.magmaguy.elitemobs.items.customenchantments.SummonMerchantEnchantment;
 import com.magmaguy.elitemobs.npcs.NPCEntity;
 import com.magmaguy.elitemobs.utils.Round;
 import org.bukkit.Location;
@@ -30,6 +31,10 @@ public class NPCCommands {
             case "remove":
                 if (permCheck(CommandHandler.NPC, commandSender))
                     removeNPC((Player) commandSender, args);
+                break;
+            case "merchant":
+                if (permCheck(CommandHandler.NPC, commandSender))
+                    SummonMerchantEnchantment.doSummonMerchant(((Player) commandSender), false, null);
                 break;
             default:
         }

--- a/src/main/java/com/magmaguy/elitemobs/config/customloot/CustomLootConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/customloot/CustomLootConfig.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 
 public class CustomLootConfig {
 
-    private static ArrayList<CustomLootConfigFields> customLootConfigFieldsList = new ArrayList<>(Arrays.asList(
+    private static final ArrayList<CustomLootConfigFields> customLootConfigFieldsList = new ArrayList<>(Arrays.asList(
             new BerserkerCharmConfig(),
             new ChameleonCharmConfig(),
             new CheetahCharmConfig(),
@@ -34,7 +34,8 @@ public class CustomLootConfig {
             new TheFellerConfig(),
             new VampiricCharmConfig(),
             new ZombieKingsAxeConfig(),
-            new MeteorShowerScrollConfig()
+            new MeteorShowerScrollConfig(),
+            new SummonMerchantScrollConfig()
     ));
 
     public static void initializeConfigs() {

--- a/src/main/java/com/magmaguy/elitemobs/config/customloot/premade/SummonMerchantScrollConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/customloot/premade/SummonMerchantScrollConfig.java
@@ -1,0 +1,21 @@
+package com.magmaguy.elitemobs.config.customloot.premade;
+
+import com.magmaguy.elitemobs.config.customloot.CustomLootConfigFields;
+import org.bukkit.Material;
+
+import java.util.Arrays;
+
+public class SummonMerchantScrollConfig extends CustomLootConfigFields {
+    public SummonMerchantScrollConfig() {
+        super("summon_merchant_scroll",
+                true,
+                Material.PAPER.toString(),
+                "&6Summon Merchant Scroll",
+                Arrays.asList("&aNeed to sell an item?", "&aRight-click to activate", "&aor yell &9Jeeves!"),
+                Arrays.asList("SUMMON_MERCHANT,1"),
+                null,
+                "2",
+                null,
+                "custom");
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/enchantments/EnchantmentsConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/enchantments/EnchantmentsConfig.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 
 public class EnchantmentsConfig {
 
-    private static HashMap<String, EnchantmentsConfigFields> enchantments = new HashMap();
+    private static final HashMap<String, EnchantmentsConfigFields> enchantments = new HashMap();
 
     public static void addPowers(String fileName, EnchantmentsConfigFields enchantmentsConfigFields) {
         enchantments.put(fileName, enchantmentsConfigFields);
@@ -34,7 +34,7 @@ public class EnchantmentsConfig {
         return null;
     }
 
-    private static ArrayList<EnchantmentsConfigFields> enchantmentsConfigFields = new ArrayList(Arrays.asList(
+    private static final ArrayList<EnchantmentsConfigFields> enchantmentsConfigFields = new ArrayList(Arrays.asList(
             new ArrowDamageConfig(),
             new ArrowFireConfig(),
             new ArrowInfiniteConfig(),
@@ -80,7 +80,8 @@ public class EnchantmentsConfig {
             new CriticalStrikesConfig(),
             new MeteorShowerConfig(),
             new DrillingConfig(),
-            new IceBreakerConfig()
+            new IceBreakerConfig(),
+            new SummonMerchantConfig()
     ));
 
     public static void initializeConfigs() {

--- a/src/main/java/com/magmaguy/elitemobs/config/enchantments/premade/SummonMerchantConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/enchantments/premade/SummonMerchantConfig.java
@@ -1,0 +1,14 @@
+package com.magmaguy.elitemobs.config.enchantments.premade;
+
+import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfigFields;
+
+public class SummonMerchantConfig extends EnchantmentsConfigFields {
+    public SummonMerchantConfig() {
+        super("summon_merchant",
+                true,
+                "Summon Merchant",
+                1,
+                10);
+        super.getAdditionalConfigOptions().put("message", "Jeeves!");
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/npcs/NPCsConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/npcs/NPCsConfig.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 
 public class NPCsConfig {
 
-    private static HashMap<String, NPCsConfigFields> NPCsList = new HashMap<>();
+    private static final HashMap<String, NPCsConfigFields> NPCsList = new HashMap<>();
 
     public static HashMap<String, NPCsConfigFields> getNPCsList() {
         return NPCsList;
@@ -25,13 +25,14 @@ public class NPCsConfig {
         NPCsList.put(fileName, npCsConfigFields);
     }
 
-    private static ArrayList<NPCsConfigFields> NPCsConfigFieldsList = new ArrayList<NPCsConfigFields>(Arrays.asList(
+    private static final ArrayList<NPCsConfigFields> NPCsConfigFieldsList = new ArrayList<NPCsConfigFields>(Arrays.asList(
             new BarkeepConfig(),
             new BlacksmithConfig(),
             new GuildAttendantConfig(),
             new QuestGiverConfig(),
             new SpecialBlacksmithConfig(),
-            new CombatInstructorConfig()
+            new CombatInstructorConfig(),
+            new TravellingMerchantConfig()
     ));
 
     public static void initializeConfigs() {

--- a/src/main/java/com/magmaguy/elitemobs/config/npcs/NPCsConfigFields.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/npcs/NPCsConfigFields.java
@@ -5,7 +5,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class NPCsConfigFields {
 
@@ -25,6 +27,8 @@ public class NPCsConfigFields {
     private final String interactionType;
     private FileConfiguration fileConfiguration = null;
     private File file;
+    private double timeout;
+    private final HashMap<String, Object> additionalConfigOptions = new HashMap<>();
 
     public NPCsConfigFields(String fileName,
                             boolean isEnabled,
@@ -54,6 +58,7 @@ public class NPCsConfigFields {
         this.activationRadius = activationRadius;
         this.canSleep = canSleep;
         this.interactionType = interactionType;
+
     }
 
     public void generateConfigDefaults(FileConfiguration fileConfiguration) {
@@ -70,6 +75,8 @@ public class NPCsConfigFields {
         fileConfiguration.addDefault("activationRadius", activationRadius);
         fileConfiguration.addDefault("canSleep", canSleep);
         fileConfiguration.addDefault("interactionType", interactionType);
+        if (!additionalConfigOptions.isEmpty())
+            fileConfiguration.addDefaults(additionalConfigOptions);
     }
 
     public NPCsConfigFields(FileConfiguration fileConfiguration, File file) {
@@ -89,6 +96,10 @@ public class NPCsConfigFields {
         this.activationRadius = fileConfiguration.getDouble("activationRadius");
         this.canSleep = fileConfiguration.getBoolean("canSleep");
         this.interactionType = fileConfiguration.getString("interactionType");
+        if (fileConfiguration.getString("timeout") != null)
+            this.timeout = fileConfiguration.getDouble("timeout");
+        else
+            this.timeout = 0;
     }
 
     public String getFileName() {
@@ -170,6 +181,14 @@ public class NPCsConfigFields {
         } catch (Exception ex) {
             Bukkit.getLogger().warning("[EliteMobs] Attempted to update the location status for an NPC with no config file! Did you delete it during runtime?");
         }
+    }
+
+    public Map<String, Object> getAdditionalConfigOptions() {
+        return additionalConfigOptions;
+    }
+
+    public double getTimeout() {
+        return this.timeout;
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/config/npcs/premade/TravellingMerchantConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/npcs/premade/TravellingMerchantConfig.java
@@ -1,0 +1,38 @@
+package com.magmaguy.elitemobs.config.npcs.premade;
+
+import com.magmaguy.elitemobs.config.npcs.NPCsConfigFields;
+
+import java.util.Arrays;
+
+public class TravellingMerchantConfig extends NPCsConfigFields {
+    public TravellingMerchantConfig() {
+        super(
+                "travelling_merchant.yml",
+                true,
+                "Jeeves",
+                "<Travelling Merchant>",
+                "LIBRARIAN",
+                null,
+                Arrays.asList(
+                        "Got something to sell?",
+                        "You called?",
+                        "Huh?"),
+                Arrays.asList(
+                        "I'll buy it on the cheap!",
+                        "Got something for me?",
+                        "Time is money!"),
+                Arrays.asList(
+                        "Call me again anytime!",
+                        "Was that all?",
+                        "Safe travels!",
+                        "Don't get yourself killed!",
+                        "Good hunting!"),
+                false,
+                true,
+                3,
+                false,
+                "SELL"
+        );
+        super.getAdditionalConfigOptions().put("timeout", 2);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/items/ItemTagger.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/ItemTagger.java
@@ -35,8 +35,7 @@ public class ItemTagger {
      * @param itemStack ItemStack to which custom lore should be added
      * @param lore      Custom part of the lore to add
      */
-    public static void registerCustomLore(ItemStack itemStack, List<String> lore) {
-        ItemMeta itemMeta = itemStack.getItemMeta();
+    public static void registerCustomLore(ItemMeta itemMeta, List<String> lore) {
         StringBuilder parsedLore = new StringBuilder();
         for (int i = 0; i < lore.size(); i++) {
             parsedLore.append(lore.get(i));
@@ -44,7 +43,6 @@ public class ItemTagger {
                 parsedLore.append("\n");
         }
         itemMeta.getPersistentDataContainer().set(customLore, PersistentDataType.STRING, parsedLore.toString());
-        itemStack.setItemMeta(itemMeta);
     }
 
     /**

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CriticalStrikesEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CriticalStrikesEnchantment.java
@@ -18,7 +18,7 @@ public class CriticalStrikesEnchantment extends CustomEnchantment {
     public static void criticalStrikePopupMessage(Entity entity, Vector offset) {
         DialogArmorStand.createDialogArmorStand(entity,
                 ChatColorConverter.convert(EnchantmentsConfig.getEnchantment("critical_strikes.yml")
-                        .getFileConfiguration().getString("criticalHitPopup")), new Vector(0, 0, 0));
+                        .getFileConfiguration().getString("criticalHitPopup")), offset);
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CustomEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/CustomEnchantment.java
@@ -20,7 +20,7 @@ public abstract class CustomEnchantment {
         return customEnchantments;
     }
 
-    private final String key;
+    public final String key;
     private final boolean dynamic;
     private final EnchantmentsConfigFields enchantmentsConfigFields;
     private final Enchantment originalEnchantment = null;
@@ -47,6 +47,7 @@ public abstract class CustomEnchantment {
         new DrillingEnchantment();
         new IceBreakerEnchantment();
         new MeteorShowerEnchantment();
+        new SummonMerchantEnchantment();
     }
 
     /*

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/SummonMerchantEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/SummonMerchantEnchantment.java
@@ -1,0 +1,102 @@
+package com.magmaguy.elitemobs.items.customenchantments;
+
+import com.magmaguy.elitemobs.ChatColorConverter;
+import com.magmaguy.elitemobs.MetadataHandler;
+import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfig;
+import com.magmaguy.elitemobs.items.ItemTagger;
+import com.magmaguy.elitemobs.npcs.NPCEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.ArrayList;
+
+public class SummonMerchantEnchantment extends CustomEnchantment implements Listener {
+
+    public static String key = "summon_merchant";
+
+    private static final String merchantMessage = EnchantmentsConfig.getEnchantment("summon_merchant.yml").getFileConfiguration().getString("message");
+
+    public SummonMerchantEnchantment() {
+        super(key, false);
+    }
+
+    /**
+     * If the value is 0, it means that the enchantment isn't present
+     */
+    private static int getEnchantment(ItemMeta itemMeta) {
+        return ItemTagger.getEnchantment(itemMeta, key);
+    }
+
+    /**
+     * Summons the merchant
+     *
+     * @param player
+     */
+    public static void doSummonMerchant(Player player, boolean fromMessage, ItemStack itemStack) {
+        if (itemStack != null)
+            itemStack.setAmount(itemStack.getAmount() - 1);
+        if (!fromMessage) {
+            new NPCEntity(player.getLocation());
+            if (!merchantMessage.isEmpty())
+                player.chat(ChatColorConverter.convert(merchantMessage));
+            return;
+        }
+        //pass to a sync task
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                new NPCEntity(player.getLocation());
+            }
+        }.runTask(MetadataHandler.PLUGIN);
+    }
+
+    public static class SummonMerchantEvents implements Listener {
+        private static final ArrayList<Player> playerCooldowns = new ArrayList<>();
+
+        @EventHandler
+        public void onItemInteract(PlayerInteractEvent event) {
+            if (!(event.getAction().equals(Action.RIGHT_CLICK_AIR) || event.getAction().equals(Action.RIGHT_CLICK_BLOCK)))
+                return;
+            if (getEnchantment(event.getPlayer().getInventory().getItemInMainHand().getItemMeta()) < 1)
+                return;
+            if (playerCooldowns.contains(event.getPlayer())) return;
+            playerCooldowns.add(event.getPlayer());
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    playerCooldowns.remove(event.getPlayer());
+                }
+            }.runTaskLater(MetadataHandler.PLUGIN, 20 * 60);
+            doSummonMerchant(event.getPlayer(), false, event.getPlayer().getInventory().getItemInMainHand());
+        }
+
+        @EventHandler
+        public void onPlayerChat(AsyncPlayerChatEvent event) {
+            if (merchantMessage.isEmpty()) return;
+            if (event.getMessage().equalsIgnoreCase(merchantMessage)) {
+                if (playerCooldowns.contains(event.getPlayer())) return;
+                playerCooldowns.add(event.getPlayer());
+                new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        playerCooldowns.remove(event.getPlayer());
+                    }
+                }.runTaskLater(MetadataHandler.PLUGIN, 20 * 60);
+                for (ItemStack itemStack : event.getPlayer().getInventory())
+                    if (itemStack != null)
+                        if (getEnchantment(itemStack.getItemMeta()) > 0) {
+                            doSummonMerchant(event.getPlayer(), true, itemStack);
+                            return;
+                        }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/magmaguy/elitemobs/items/customitems/CustomItem.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customitems/CustomItem.java
@@ -3,7 +3,6 @@ package com.magmaguy.elitemobs.items.customitems;
 import com.magmaguy.elitemobs.adventurersguild.GuildRank;
 import com.magmaguy.elitemobs.config.AdventurersGuildConfig;
 import com.magmaguy.elitemobs.config.customloot.CustomLootConfigFields;
-import com.magmaguy.elitemobs.items.ItemTagger;
 import com.magmaguy.elitemobs.items.ItemTierFinder;
 import com.magmaguy.elitemobs.items.LootTables;
 import com.magmaguy.elitemobs.items.ScalableItemConstructor;
@@ -266,6 +265,13 @@ public class CustomItem {
                     Bukkit.getLogger().warning("[EliteMobs] The name should follow the API names and the level should be above 0.");
                     Bukkit.getLogger().warning("[EliteMobs] Defaulting " + name + " to level 1.");
                 }
+/*
+                for (CustomEnchantment customEnchantment : CustomEnchantment.getCustomEnchantments())
+                    if (customEnchantment.key.equalsIgnoreCase(name)){
+                        customEnchantments.put(name.toLowerCase(), level);
+                        break;
+                    }
+*/
 
                 if (name.equalsIgnoreCase(HunterEnchantment.key) ||
                         name.equalsIgnoreCase(FlamethrowerEnchantment.key) ||
@@ -273,10 +279,12 @@ public class CustomItem {
                         name.equalsIgnoreCase(MeteorShowerEnchantment.key) ||
                         name.equalsIgnoreCase(SoulbindEnchantment.key) ||
                         name.equalsIgnoreCase(DrillingEnchantment.key) ||
-                        name.equalsIgnoreCase(IceBreakerEnchantment.key)) {
+                        name.equalsIgnoreCase(IceBreakerEnchantment.key) ||
+                        name.equalsIgnoreCase(SummonMerchantEnchantment.key)) {
                     customEnchantments.put(name.toLowerCase(), level);
                     continue;
                 }
+
 
                 Enchantment enchantment;
 
@@ -394,8 +402,6 @@ public class CustomItem {
                         player,
                         showItemWorth);
         parseCustomModelID(itemStack);
-        if (!lore.isEmpty())
-            ItemTagger.registerCustomLore(itemStack, lore);
         return itemStack;
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/ItemConstructor.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/ItemConstructor.java
@@ -4,6 +4,7 @@ import com.magmaguy.elitemobs.config.ItemSettingsConfig;
 import com.magmaguy.elitemobs.items.EliteItemLore;
 import com.magmaguy.elitemobs.items.ItemTagger;
 import com.magmaguy.elitemobs.items.customenchantments.SoulbindEnchantment;
+import com.magmaguy.elitemobs.items.potioneffects.ElitePotionEffectContainer;
 import com.magmaguy.elitemobs.mobconstructor.EliteMobEntity;
 import com.magmaguy.elitemobs.utils.ItemStackGenerator;
 import org.bukkit.Material;
@@ -50,10 +51,20 @@ public class ItemConstructor {
         if (!enchantments.isEmpty())
             itemMeta = EnchantmentGenerator.generateEnchantments(itemMeta, enchantments);
 
+        itemStack.setItemMeta(itemMeta);
+
         /*
         Generate item lore
          */
-        itemMeta = LoreGenerator.generateLore(itemMeta, itemMaterial, enchantments, customEnchantments, potionEffects, lore, eliteMobEntity);
+        if (!lore.isEmpty())
+            ItemTagger.registerCustomLore(itemMeta, lore);
+        //itemMeta = LoreGenerator.generateLore(itemMeta, itemMaterial, enchantments, customEnchantments, potionEffects, lore, eliteMobEntity);
+
+        //Tag the item
+        ItemTagger.registerEnchantments(itemMeta, enchantments);
+        ItemTagger.registerCustomEnchantments(itemMeta, customEnchantments);
+        //Tag the potion effects
+        new ElitePotionEffectContainer(itemMeta, potionEffects);
 
         /*
         Remove vanilla enchantments
@@ -126,7 +137,7 @@ public class ItemConstructor {
         /*
         Generate item lore
          */
-        itemMeta = LoreGenerator.generateLore(itemMeta, itemMaterial, enchantmentMap, customEnchantmentMap, killedMob);
+        //itemMeta = LoreGenerator.generateLore(itemMeta, itemMaterial, enchantmentMap, customEnchantmentMap, killedMob);
 
         /*
         Remove vanilla enchantments
@@ -156,6 +167,10 @@ public class ItemConstructor {
         Register item source for lore redraw
          */
         ItemTagger.registerItemSource(killedMob, itemStack);
+
+        //Tag the item
+        ItemTagger.registerEnchantments(itemMeta, enchantmentMap);
+        ItemTagger.registerCustomEnchantments(itemMeta, customEnchantmentMap);
 
         /*
         Update lore

--- a/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/LoreGenerator.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/itemconstructor/LoreGenerator.java
@@ -1,24 +1,20 @@
 package com.magmaguy.elitemobs.items.itemconstructor;
 
-import com.magmaguy.elitemobs.ChatColorConverter;
-import com.magmaguy.elitemobs.config.EconomySettingsConfig;
-import com.magmaguy.elitemobs.config.ItemSettingsConfig;
-import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfig;
-import com.magmaguy.elitemobs.config.potioneffects.PotionEffectsConfig;
-import com.magmaguy.elitemobs.items.EliteEnchantments;
 import com.magmaguy.elitemobs.items.ItemTagger;
-import com.magmaguy.elitemobs.items.ItemTierFinder;
-import com.magmaguy.elitemobs.items.ItemWorthCalculator;
 import com.magmaguy.elitemobs.items.potioneffects.ElitePotionEffectContainer;
 import com.magmaguy.elitemobs.mobconstructor.EliteMobEntity;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+/*
+ * todo: This class is now redundant and has been replaced with EliteItemLore, which is able to parse and redraw items during runtime
+ * However, this class also applies a lot of things to items, and as such should be repurposed as a custom enchant and potion effect
+ * applier.
+ */
 
 public class LoreGenerator {
 
@@ -28,6 +24,7 @@ public class LoreGenerator {
                                         List<String> potionList, List<String> loreList,
                                         EliteMobEntity eliteMobEntity) {
 
+        /*
         List<String> lore = new ArrayList<>();
 
         for (Object object : ItemSettingsConfig.loreStructure) {
@@ -59,12 +56,14 @@ public class LoreGenerator {
 
         }
 
+         */
+
         //Tag the item
         ItemTagger.registerEnchantments(itemMeta, enchantmentMap);
         ItemTagger.registerCustomEnchantments(itemMeta, customEnchantments);
         //Tag the potion effects
         new ElitePotionEffectContainer(itemMeta, potionList);
-        itemMeta.setLore(lore);
+        //itemMeta.setLore(lore);
 
         return itemMeta;
 
@@ -76,6 +75,7 @@ public class LoreGenerator {
                                         HashMap<String, Integer> customEnchantments,
                                         EliteMobEntity eliteMobEntity) {
 
+        /*
         List<String> lore = new ArrayList<>();
 
         itemMeta = applyVanillaEnchantments(enchantmentMap, itemMeta);
@@ -106,7 +106,10 @@ public class LoreGenerator {
 
         }
 
+
+
         itemMeta.setLore(lore);
+         */
 
         ItemTagger.registerEnchantments(itemMeta, enchantmentMap);
         ItemTagger.registerCustomEnchantments(itemMeta, customEnchantments);
@@ -115,6 +118,7 @@ public class LoreGenerator {
 
     }
 
+    /*
     private static List<String> enchantmentLore(HashMap<Enchantment, Integer> enchantmentMap) {
 
         List<String> enchantmentsLore = new ArrayList<>();
@@ -256,5 +260,7 @@ public class LoreGenerator {
         return colorizedLore;
 
     }
+
+     */
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/CustomBossEntity.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/CustomBossEntity.java
@@ -218,13 +218,14 @@ public class CustomBossEntity extends EliteMobEntity implements Listener {
                                       int mobLevel,
                                       HashSet<ElitePower> elitePowers) {
         if (super.getLivingEntity() == null) {
+            this.uuid = null;
             new WarningMessage("Failed to spawn boss " + customBossConfigFields.getFileName() + " . Cause for failure:" +
                     " Tried to spawn in a region that prevented it from spawning. This is probably not an EliteMobs issue," +
                     " but a region management issue. Check if mobs are allowed to spawn where you are trying to spawn it. Location: "
                     + location.toString());
             return;
         }
-        uuid = super.getLivingEntity().getUniqueId();
+        this.uuid = super.getLivingEntity().getUniqueId();
         super.setDamageMultiplier(customBossConfigFields.getDamageMultiplier());
         super.setHealthMultiplier(customBossConfigFields.getHealthMultiplier());
         super.setHasSpecialLoot(customBossConfigFields.getDropsEliteMobsLoot());

--- a/src/main/java/com/magmaguy/elitemobs/npcs/NPCInteractions.java
+++ b/src/main/java/com/magmaguy/elitemobs/npcs/NPCInteractions.java
@@ -5,6 +5,7 @@ import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.adventurersguild.GuildRankMenuHandler;
 import com.magmaguy.elitemobs.commands.shops.CustomShopMenu;
 import com.magmaguy.elitemobs.commands.shops.ProceduralShopMenu;
+import com.magmaguy.elitemobs.commands.shops.SellMenu;
 import com.magmaguy.elitemobs.quests.QuestsMenu;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
@@ -24,7 +25,8 @@ public class NPCInteractions implements Listener {
         BAR,
         ARENA,
         QUEST_GIVER,
-        NONE
+        NONE,
+        SELL
     }
 
     @EventHandler
@@ -86,7 +88,18 @@ public class NPCInteractions implements Listener {
                 break;
             case ARENA:
                 break;
+            case SELL:
+                if (event.getPlayer().hasPermission("elitemobs.shop.npc"))
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            SellMenu sellMenu = new SellMenu();
+                            sellMenu.constructSellMenu(event.getPlayer());
+                        }
+                    }.runTaskLater(MetadataHandler.PLUGIN, 1);
+                break;
             case NONE:
+            default:
                 break;
 
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EliteMobs
-version: 7.2.1
+version: 7.2.3
 author: MagmaGuy
 main: com.magmaguy.elitemobs.EliteMobs
 api-version: 1.14


### PR DESCRIPTION
- [New] Added the Travelling Merchant NPC
- [New] Added the summon_travelling_merchant enchantment
- [New] Added the Summon Merchant Scroll default custom item
- [New] Added the SELL interaction to NPCs
- [New] Players are now able to summon the Travelling merchant using the summon travelling merchant enchantment on the Summon Merchant Scroll. This can be triggered by pressing right-click or saying "Jeeves!" in chat (configurable). The item is single-use and can be bought at the Custom Items Shop or looted from any mob.
- [HOTFIX] Fixed issue where regional bosses wouldn't despawn when the timer timed out
- [Fix] Fixed issue where users in permissionless mode couldn't interact with the adventurer's guild npc
- [Fix] Fixed location of critical strike messages, no longer on the floor
- [Fix] LibsDisguises repo is currently not working correctly, this introduces a temporary fix for it
- [Fix] Custom lore now correctly displays at all times
- [Tweak] Improved performance of lore generation

Signed-off-by: MagmaGuy <tiagoarnaut@gmail.com>