### PR TITLE
Version 7.2.9

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,23 +4,23 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.magmaguy</groupId>
     <artifactId>EliteMobs</artifactId>
-    <version>7.2.8</version>
+    <version>7.2.9</version>
     <build>
         <defaultGoal>clean resources:resources package</defaultGoal>
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.2</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
+                <version>3.6.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
           <execution>
             <phase>package</phase>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.magmaguy</groupId>
     <artifactId>EliteMobs</artifactId>
-    <version>7.2.8</version>
+    <version>7.2.9</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/magmaguy/elitemobs/EliteMobs.java
+++ b/src/main/java/com/magmaguy/elitemobs/EliteMobs.java
@@ -12,6 +12,7 @@ import com.magmaguy.elitemobs.config.custombosses.CustomBossConfigFields;
 import com.magmaguy.elitemobs.config.custombosses.CustomBossesConfig;
 import com.magmaguy.elitemobs.config.customloot.CustomLootConfig;
 import com.magmaguy.elitemobs.config.customtreasurechests.CustomTreasureChestsConfig;
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfig;
 import com.magmaguy.elitemobs.config.enchantments.EnchantmentsConfig;
 import com.magmaguy.elitemobs.config.events.EventsConfig;
 import com.magmaguy.elitemobs.config.menus.MenusConfig;
@@ -19,6 +20,7 @@ import com.magmaguy.elitemobs.config.mobproperties.MobPropertiesConfig;
 import com.magmaguy.elitemobs.config.npcs.NPCsConfig;
 import com.magmaguy.elitemobs.config.potioneffects.PotionEffectsConfig;
 import com.magmaguy.elitemobs.config.powers.PowersConfig;
+import com.magmaguy.elitemobs.dungeons.Minidungeon;
 import com.magmaguy.elitemobs.economy.VaultCompatibility;
 import com.magmaguy.elitemobs.events.EventLauncher;
 import com.magmaguy.elitemobs.gamemodes.nightmaremodeworld.DaylightWatchdog;
@@ -213,6 +215,7 @@ public class EliteMobs extends JavaPlugin {
         CustomBossConfigFields.getRegionalElites().clear();
         CustomBossConfigFields.getNaturallySpawnedElites().clear();
         CustomEnchantment.getCustomEnchantments().clear();
+        Minidungeon.minidungeons.clear();
 
         if (this.placeholders != null)
             ((Placeholders) placeholders).unregister();
@@ -254,6 +257,7 @@ public class EliteMobs extends JavaPlugin {
         CommandsConfig.initializeConfigs();
         EventsConfig.initializeConfigs();
         DiscordSRVConfig.initializeConfig();
+        DungeonPackagerConfig.initializeConfigs();
     }
 
     public static void worldScanner() {

--- a/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
+++ b/src/main/java/com/magmaguy/elitemobs/EventsRegistrer.java
@@ -11,6 +11,7 @@ import com.magmaguy.elitemobs.combatsystem.combattag.TeleportTag;
 import com.magmaguy.elitemobs.combatsystem.displays.DamageDisplay;
 import com.magmaguy.elitemobs.combatsystem.displays.HealthDisplay;
 import com.magmaguy.elitemobs.commands.getLootMenu;
+import com.magmaguy.elitemobs.commands.setup.SetupMenu;
 import com.magmaguy.elitemobs.commands.shops.BuyOrSellMenu;
 import com.magmaguy.elitemobs.commands.shops.CustomShopMenu;
 import com.magmaguy.elitemobs.commands.shops.ProceduralShopMenu;
@@ -221,6 +222,7 @@ public class EventsRegistrer {
         pluginManager.registerEvents(new CustomShopMenu(), plugin);
         pluginManager.registerEvents(new BuyOrSellMenu(), plugin);
         pluginManager.registerEvents(new SellMenu(), plugin);
+        pluginManager.registerEvents(new SetupMenu.SetupMenuListeners(), plugin);
 
         //Minecraft behavior canceller
         pluginManager.registerEvents(new ChunkUnloadMetadataPurge(), plugin);

--- a/src/main/java/com/magmaguy/elitemobs/commands/CustomBossCommandHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/CustomBossCommandHandler.java
@@ -44,6 +44,9 @@ public class CustomBossCommandHandler {
                 return;
             case "setleashradius":
                 setLeashRadius(customBossConfigFields, player, args);
+                break;
+            case "remove":
+                break;
             default:
                 return;
         }
@@ -85,6 +88,10 @@ public class CustomBossCommandHandler {
         for (RegionalBossEntity regionalBossEntity : RegionalBossEntity.getRegionalBossEntityList())
             if (customBossConfigFields.getFileName().equals(regionalBossEntity.getCustomBossConfigFields().getFileName()))
                 regionalBossEntity.setLeashRadius(leashRadius);
+
+    }
+
+    private static void removeRegionalBoss() {
 
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/commands/SetupHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/SetupHandler.java
@@ -2,6 +2,7 @@ package com.magmaguy.elitemobs.commands;
 
 import com.magmaguy.elitemobs.ChatColorConverter;
 import com.magmaguy.elitemobs.EliteMobs;
+import com.magmaguy.elitemobs.commands.setup.SetupMenu;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -12,6 +13,12 @@ public class SetupHandler {
     private Player player;
 
     public SetupHandler(Player player, String[] args) {
+
+        if (args.length == 1) {
+            new SetupMenu(player);
+            return;
+        }
+
         if (!EliteMobs.worldguardIsEnabled) {
             player.sendMessage("[EliteMobs] You don't have WorldGuard installed! It is not possible to correctly set " +
                     "up a lair/minidungeon/dungeon without that plugin!");
@@ -29,54 +36,58 @@ public class SetupHandler {
 
         regionName = args[2];
         this.player = player;
+        protectArea(player, regionName);
+    }
 
+    public static void protectArea(Player player, String regionName) {
         //elitemobs flags
-        commandPackage("&3", "elitemobs-dungeon", "allow");
-        commandPackage("&3", "elitemobs-antiexploit", "deny");
-        commandPackage("&3", "elitemobs-events", "deny");
+        commandPackage("&3", "elitemobs-dungeon", "allow", player, regionName);
+        commandPackage("&3", "elitemobs-antiexploit", "deny", player, regionName);
+        commandPackage("&3", "elitemobs-events", "deny", player, regionName);
 
         //worldguard flags
-        commandPackage("&a", "interact", "deny");
-        commandPackage("&a", "creeper-explosion", "deny");
-        commandPackage("&a", "fire-spread", "deny");
-        commandPackage("&a", "lava-fire", "deny");
-        commandPackage("&a", "snow-fall", "deny");
-        commandPackage("&a", "snow-melt", "deny");
-        commandPackage("&a", "ice-form", "deny");
-        commandPackage("&a", "ice-melt", "deny");
-        commandPackage("&a", "frosted-ice-melt", "deny");
-        commandPackage("&a", "frosted-ice-form", "deny");
-        commandPackage("&a", "leaf-decay", "false");
-        commandPackage("&a", "grass-growth", "false");
-        commandPackage("&a", "mycelium-spread", "deny");
-        commandPackage("&a", "crop-growth", "deny");
-        commandPackage("&a", "soil-dry", "deny");
-        commandPackage("&a", "coral-fade", "deny");
-        commandPackage("&a", "ravager-grief", "deny");
-        commandPackage("&a", "ghast-fireball", "deny");
-        commandPackage("&a", "wither-damage", "deny");
-        commandPackage("&a", "enderman-grief", "deny");
-        commandPackage("&a", "item-frame-rotation", "deny");
-        commandPackage("&a", "vehicle-place", "deny");
-        commandPackage("&a", "vehicle-destroy", "deny");
-        commandPackage("&a", "pvp", "deny");
-        commandPackage("&a", "other-explosion", "deny");
-        commandPackage("&a", "block-trampling", "deny");
-        commandPackage("&a", "vine-growth", "deny");
-        commandPackage("&a", "mushroom-growth", "deny");
-        commandPackage("&a", "damage-animals", "allow");
-        commandPackage("&a", "sleep", "deny");
-        commandPackage("&a", "chest-access", "allow");
-        commandPackage("&a", "entity-painting-destroy", "deny");
-        commandPackage("&a", "mob-spawning", "allow");
-        commandPackage("&a", "tnt", "deny");
-        commandPackage("&a", "ender-dragon-block-damage", "deny");
-        commandPackage("&a", "lighter", "deny");
-        commandPackage("&a", "enderpearl", "deny");
+        commandPackage("&a", "interact", "deny", player, regionName);
+        commandPackage("&a", "creeper-explosion", "deny", player, regionName);
+        commandPackage("&a", "fire-spread", "deny", player, regionName);
+        commandPackage("&a", "lava-fire", "deny", player, regionName);
+        commandPackage("&a", "lava-flow", "deny", player, regionName);
+        commandPackage("&a", "snow-fall", "deny", player, regionName);
+        commandPackage("&a", "snow-melt", "deny", player, regionName);
+        commandPackage("&a", "ice-form", "deny", player, regionName);
+        commandPackage("&a", "ice-melt", "deny", player, regionName);
+        commandPackage("&a", "frosted-ice-melt", "deny", player, regionName);
+        commandPackage("&a", "frosted-ice-form", "deny", player, regionName);
+        commandPackage("&a", "leaf-decay", "false", player, regionName);
+        commandPackage("&a", "grass-growth", "false", player, regionName);
+        commandPackage("&a", "mycelium-spread", "deny", player, regionName);
+        commandPackage("&a", "crop-growth", "deny", player, regionName);
+        commandPackage("&a", "soil-dry", "deny", player, regionName);
+        commandPackage("&a", "coral-fade", "deny", player, regionName);
+        commandPackage("&a", "ravager-grief", "deny", player, regionName);
+        commandPackage("&a", "ghast-fireball", "deny", player, regionName);
+        commandPackage("&a", "wither-damage", "deny", player, regionName);
+        commandPackage("&a", "enderman-grief", "deny", player, regionName);
+        commandPackage("&a", "item-frame-rotation", "deny", player, regionName);
+        commandPackage("&a", "vehicle-place", "deny", player, regionName);
+        commandPackage("&a", "vehicle-destroy", "deny", player, regionName);
+        commandPackage("&a", "pvp", "deny", player, regionName);
+        commandPackage("&a", "other-explosion", "deny", player, regionName);
+        commandPackage("&a", "block-trampling", "deny", player, regionName);
+        commandPackage("&a", "vine-growth", "deny", player, regionName);
+        commandPackage("&a", "mushroom-growth", "deny", player, regionName);
+        commandPackage("&a", "damage-animals", "allow", player, regionName);
+        commandPackage("&a", "sleep", "deny", player, regionName);
+        commandPackage("&a", "chest-access", "allow", player, regionName);
+        commandPackage("&a", "entity-painting-destroy", "deny", player, regionName);
+        commandPackage("&a", "mob-spawning", "allow", player, regionName);
+        commandPackage("&a", "tnt", "deny", player, regionName);
+        commandPackage("&a", "ender-dragon-block-damage", "deny", player, regionName);
+        commandPackage("&a", "lighter", "deny", player, regionName);
+        commandPackage("&a", "enderpearl", "deny", player, regionName);
 
         //worldguardextraflags
         if (Bukkit.getPluginManager().isPluginEnabled("WorldGuardExtraFlags")) {
-            commandPackage("&2", "fly", "deny");
+            commandPackage("&2", "fly", "deny", player, regionName);
         } else {
             player.sendMessage(ChatColor.RED + "[EliteMobs] Warning: the WorldGuardExtraFlags plugin is not present. It is recommended for the use of the anti-flight flag.");
         }
@@ -85,16 +96,16 @@ public class SetupHandler {
 
     }
 
-    private void commandPackage(String colorCode, String flagString, String state) {
-        player.sendMessage(flagString(colorCode + flagString));
-        player.performCommand(commandString(flagString, state));
+    private static void commandPackage(String colorCode, String flagString, String state, Player player, String regionName) {
+        player.sendMessage(flagString(colorCode + flagString, player));
+        player.performCommand(commandString(flagString, state, player, regionName));
     }
 
-    private String flagString(String flagString) {
+    private static String flagString(String flagString, Player player) {
         return ChatColorConverter.convert("&a[EliteMobs] Adding flag " + flagString);
     }
 
-    private String commandString(String flagString, String state) {
+    private static String commandString(String flagString, String state, Player player, String regionName) {
         return "region flag " + regionName + " " + flagString + " " + state;
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/commands/setup/SetupMenu.java
+++ b/src/main/java/com/magmaguy/elitemobs/commands/setup/SetupMenu.java
@@ -1,0 +1,197 @@
+package com.magmaguy.elitemobs.commands.setup;
+
+import com.magmaguy.elitemobs.ChatColorConverter;
+import com.magmaguy.elitemobs.config.AdventurersGuildConfig;
+import com.magmaguy.elitemobs.config.DefaultConfig;
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfigFields;
+import com.magmaguy.elitemobs.dungeons.Minidungeon;
+import com.magmaguy.elitemobs.utils.ItemStackGenerator;
+import com.magmaguy.elitemobs.utils.WarningMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+import java.util.*;
+
+public class SetupMenu {
+
+    public static HashMap<Inventory, SetupMenu> setupMenus = new HashMap<>();
+
+    Inventory inventory;
+    Player player;
+    ArrayList<Integer> validSlots = new ArrayList<>(Arrays.asList(10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23,
+            24, 25, 28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 43));
+    HashMap<Integer, Minidungeon> minidungeonHashMap = new HashMap<>();
+
+    public SetupMenu(Player player) {
+        this.inventory = Bukkit.createInventory(player, 54, "Setup menu");
+        this.player = player;
+        //reserves the first slot
+        permissionsStatus();
+        //reserve adventurer's guild
+        adventurersGuildWorldStatus();
+        //iterate through dungeons
+        dungeonStatuses();
+        setupMenus.put(inventory, this);
+        player.openInventory(inventory);
+    }
+
+    private void permissionsStatus() {
+
+        String name = "Currently using";
+        String state;
+        if (DefaultConfig.usePermissions)
+            state = "Permissions!";
+        else
+            state = "Permissionless mode!";
+
+        Material material;
+        if (!DefaultConfig.setupDone) {
+            material = Material.RED_STAINED_GLASS_PANE;
+            state = ChatColor.RED + state;
+        } else {
+            material = Material.GREEN_STAINED_GLASS_PANE;
+            state = ChatColor.GREEN + state;
+        }
+
+        inventory.setItem(validSlots.get(0), ItemStackGenerator.generateItemStack(material, name, Collections.singletonList(state)));
+    }
+
+    private void adventurersGuildWorldStatus() {
+        String state = "Adventurer's Guild world is";
+        String lore;
+        Material material;
+        if (AdventurersGuildConfig.guildWorldLocation != null) {
+            material = Material.RED_STAINED_GLASS_PANE;
+            lore = ChatColor.RED + "Not setup!";
+        } else {
+            material = Material.GREEN_STAINED_GLASS_PANE;
+            lore = ChatColor.GREEN + "Working correctly!";
+        }
+        inventory.setItem(validSlots.get(1), ItemStackGenerator.generateItemStack(material, state, new ArrayList<>(Arrays.asList(lore))));
+    }
+
+    private void dungeonStatuses() {
+        //continue counting from used inventory slots
+        int counter = 2;
+        for (Minidungeon minidungeon : Minidungeon.minidungeons.values()) {
+
+            switch (minidungeon.dungeonPackagerConfigFields.getDungeonLocationType()) {
+                case WORLD:
+                    addWorldDungeon(minidungeon, counter);
+                    break;
+                case SCHEMATIC:
+                    addSchematicDungeon(minidungeon, counter);
+                    break;
+                default:
+                    new WarningMessage("Dungeon " + minidungeon.dungeonPackagerConfigFields.getFileName() + " does not have a valid location type and therefore can't be set up automatically!");
+                    break;
+            }
+            minidungeonHashMap.put(validSlots.get(counter), minidungeon);
+            counter++;
+
+        }
+    }
+
+    private void addWorldDungeon(Minidungeon minidungeon, int counter) {
+
+        String itemName = minidungeon.dungeonPackagerConfigFields.getName();
+        List<String> lore = new ArrayList<>();
+
+        addSize(lore, minidungeon);
+        //boss count can't be calculated ahead of time here, unfortunately
+        addInstallationString(lore, minidungeon);
+
+        lore = ChatColorConverter.convert(lore);
+        inventory.setItem(validSlots.get(counter), ItemStackGenerator.generateItemStack(getMaterial(minidungeon), itemName, lore));
+    }
+
+    private void addSchematicDungeon(Minidungeon minidungeon, int counter) {
+        if (!Bukkit.getPluginManager().isPluginEnabled("WorldEdit")) {
+            inventory.setItem(validSlots.get(counter), ItemStackGenerator.generateItemStack(Material.RED_STAINED_GLASS_PANE, ChatColorConverter.convert("&4You need WorldEdit to use this!")));
+            return;
+        }
+
+        String itemName = minidungeon.dungeonPackagerConfigFields.getName();
+
+        List<String> lore = new ArrayList<>();
+        if (minidungeon.dungeonPackagerConfigFields.getCustomInfo() != null)
+            lore.addAll(minidungeon.dungeonPackagerConfigFields.getCustomInfo());
+        addSize(lore, minidungeon);
+        addBossCount(lore, minidungeon);
+        addInstallationString(lore, minidungeon);
+
+        lore = ChatColorConverter.convert(lore);
+
+        inventory.setItem(validSlots.get(counter), ItemStackGenerator.generateItemStack(getMaterial(minidungeon), itemName, lore));
+    }
+
+    private Material getMaterial(Minidungeon minidungeon) {
+        if (minidungeon.isInstalled)
+            return Material.GREEN_STAINED_GLASS_PANE;
+        if (minidungeon.isDownloaded)
+            return Material.YELLOW_STAINED_GLASS_PANE;
+        return Material.RED_STAINED_GLASS_PANE;
+    }
+
+    private void addSize(List<String> lore, Minidungeon minidungeon) {
+        lore.add("&fSize: " + minidungeon.dungeonPackagerConfigFields.getDungeonSizeCategory().toString());
+    }
+
+    private void addBossCount(List<String> lore, Minidungeon minidungeon) {
+        lore.add("&fRegional boss count: " + minidungeon.relativeDungeonLocations.bossCount);
+    }
+
+    private void addInstallationString(List<String> lore, Minidungeon minidungeon) {
+        String status = "&fStatus: ";
+        if (minidungeon.isInstalled) {
+            lore.add(status + "&2already installed!");
+            lore.add("&cClick to uninstall!");
+            return;
+        }
+        if (minidungeon.isDownloaded) {
+            lore.add(status + "&aready to install!");
+            lore.add("&2Click to install!");
+        } else {
+            lore.add(status + "&4not downloaded!");
+            lore.add("&4Download this at");
+            lore.add("&9" + minidungeon.dungeonPackagerConfigFields.getDownloadLink() + " &f!");
+        }
+    }
+
+    private void addEmptyCustomBossesCase(DungeonPackagerConfigFields dungeonPackagerConfigFields, int counter) {
+
+    }
+
+
+    public static class SetupMenuListeners implements Listener {
+        @EventHandler(ignoreCancelled = true)
+        public void onInventoryInteraction(InventoryClickEvent event) {
+            SetupMenu setupMenu = setupMenus.get(event.getInventory());
+            if (setupMenu == null) return;
+            event.setCancelled(true);
+            Player player = (Player) event.getWhoClicked();
+            //for permissions mode
+            //for adventurer's guild world
+            //for minidungeons
+            Minidungeon minidungeon = setupMenu.minidungeonHashMap.get(event.getSlot());
+            if (minidungeon != null) {
+                if (!minidungeon.isDownloaded) {
+                    player.sendMessage(ChatColorConverter.convert("&4Download this at &9" + minidungeon.dungeonPackagerConfigFields.getDownloadLink()));
+                    player.closeInventory();
+                    setupMenus.remove(player);
+                    return;
+                }
+                minidungeon.buttonToggleBehavior(player);
+                setupMenus.remove(player);
+                player.closeInventory();
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/DungeonPackagerConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/DungeonPackagerConfig.java
@@ -1,0 +1,52 @@
+package com.magmaguy.elitemobs.config.dungeonpackager;
+
+import com.magmaguy.elitemobs.config.ConfigurationEngine;
+import com.magmaguy.elitemobs.config.dungeonpackager.premade.*;
+import com.magmaguy.elitemobs.dungeons.Minidungeon;
+import com.magmaguy.elitemobs.utils.WarningMessage;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class DungeonPackagerConfig {
+
+    public static final HashMap<String, DungeonPackagerConfigFields> dungeonPackages = new HashMap<>();
+
+    private static final ArrayList<DungeonPackagerConfigFields> dungeonPackagerConfigFields = new ArrayList(Arrays.asList(
+            new DarkCathedralLair(),
+            new ColosseumLair(),
+            new SewersMinidungeon(),
+            new DarkSpireMinidungeon(),
+            new HallosseumLair()
+    ));
+
+    public static void initializeConfigs() {
+        for (DungeonPackagerConfigFields dungeonPackagerConfigFields : dungeonPackagerConfigFields)
+            initializeConfiguration(dungeonPackagerConfigFields);
+
+    }
+
+    /**
+     * Initializes a single instance of a premade configuration using the default values.
+     */
+    private static FileConfiguration initializeConfiguration(DungeonPackagerConfigFields dungeonPackagerConfigFields) {
+
+        File file = ConfigurationEngine.fileCreator("dungeonpackages", dungeonPackagerConfigFields.getFileName());
+        FileConfiguration fileConfiguration = ConfigurationEngine.fileConfigurationCreator(file);
+        dungeonPackagerConfigFields.generateConfigDefaults(fileConfiguration);
+        ConfigurationEngine.fileSaverOnlyDefaults(fileConfiguration, file);
+        DungeonPackagerConfigFields dungeonPackagerConfigFields1 = new DungeonPackagerConfigFields(fileConfiguration, file);
+        dungeonPackages.put(file.getName(), dungeonPackagerConfigFields1);
+        try {
+            new Minidungeon(dungeonPackagerConfigFields1);
+        } catch (Exception ex) {
+            new WarningMessage("Error while parsing a minidungeon!");
+            ex.printStackTrace();
+        }
+        return fileConfiguration;
+
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/DungeonPackagerConfigFields.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/DungeonPackagerConfigFields.java
@@ -1,0 +1,176 @@
+package com.magmaguy.elitemobs.config.dungeonpackager;
+
+import com.magmaguy.elitemobs.ChatColorConverter;
+import com.magmaguy.elitemobs.utils.WarningMessage;
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.io.File;
+import java.util.List;
+
+public class DungeonPackagerConfigFields {
+
+    public enum DungeonLocationType {
+        WORLD,
+        SCHEMATIC
+    }
+
+    public enum DungeonSizeCategory {
+        LAIR,
+        MINIDUNGEON,
+        DUNGEON,
+        RAID
+    }
+
+    private final String fileName;
+    private boolean isEnabled;
+    private final String name;
+    private FileConfiguration fileConfiguration;
+    private DungeonLocationType dungeonLocationType;
+    private final List<String> customInfo;
+    private final List<String> relativeBossLocations;
+    private final List<String> relativeTreasureChestLocations;
+    private final String downloadLink;
+    private DungeonSizeCategory dungeonSizeCategory;
+    private String worldName;
+    private final String schematicName;
+    private World.Environment environment;
+    private final Boolean protect;
+    private File file;
+
+    public DungeonPackagerConfigFields(String fileName,
+                                       boolean isEnabled,
+                                       String name,
+                                       DungeonLocationType dungeonLocationType,
+                                       List<String> customInfo,
+                                       List<String> relativeBossLocations,
+                                       List<String> relativeTreasureChestLocations,
+                                       String downloadLink,
+                                       DungeonSizeCategory dungeonSizeCategory,
+                                       String worldName,
+                                       String schematicName,
+                                       World.Environment environment,
+                                       Boolean protect) {
+        this.fileName = fileName + ".yml";
+        this.isEnabled = isEnabled;
+        this.name = name;
+        this.dungeonLocationType = dungeonLocationType;
+        this.customInfo = customInfo;
+        this.relativeBossLocations = relativeBossLocations;
+        this.relativeTreasureChestLocations = relativeTreasureChestLocations;
+        this.downloadLink = downloadLink;
+        this.dungeonSizeCategory = dungeonSizeCategory;
+        this.worldName = worldName;
+        this.schematicName = schematicName;
+        this.worldName = worldName;
+        this.environment = environment;
+        this.protect = protect;
+    }
+
+    public void generateConfigDefaults(FileConfiguration fileConfiguration) {
+        fileConfiguration.addDefault("isEnabled", isEnabled);
+        fileConfiguration.addDefault("name", name);
+        fileConfiguration.addDefault("dungeonLocationType", dungeonLocationType.toString());
+        fileConfiguration.addDefault("customInfo", customInfo);
+        fileConfiguration.addDefault("relativeBossLocations", relativeBossLocations);
+        fileConfiguration.addDefault("relativeTreasureLocations", relativeTreasureChestLocations);
+        fileConfiguration.addDefault("downloadLink", downloadLink);
+        fileConfiguration.addDefault("dungeonSizeCategory", dungeonSizeCategory.toString());
+        fileConfiguration.addDefault("worldName", worldName);
+        fileConfiguration.addDefault("schematicName", schematicName);
+        if (environment != null)
+            fileConfiguration.addDefault("environment", environment.toString());
+        if (protect != null)
+            fileConfiguration.addDefault("protect", protect);
+    }
+
+    public DungeonPackagerConfigFields(FileConfiguration fileConfiguration, File file) {
+        this.fileName = file.getName();
+        this.fileConfiguration = fileConfiguration;
+        this.isEnabled = fileConfiguration.getBoolean("isEnabled");
+        this.name = fileConfiguration.getString("name");
+        try {
+            this.dungeonLocationType = DungeonLocationType.valueOf(fileConfiguration.getString("dungeonLocationType"));
+        } catch (Exception exception) {
+            new WarningMessage("File " + fileName + " does not have a valid dungeonLocationType!");
+        }
+        this.customInfo = fileConfiguration.getStringList("customInfo");
+        this.relativeBossLocations = fileConfiguration.getStringList("relativeBossLocations");
+        this.relativeTreasureChestLocations = fileConfiguration.getStringList("relativeTreasureChestLocations");
+        this.downloadLink = fileConfiguration.getString("downloadLink");
+        try {
+            this.dungeonSizeCategory = DungeonSizeCategory.valueOf(fileConfiguration.getString("dungeonSizeCategory"));
+        } catch (Exception exception) {
+            new WarningMessage("File " + fileName + " does not have a valid dungeonSizeCategory!");
+        }
+        this.worldName = fileConfiguration.getString("worldName");
+        this.schematicName = fileConfiguration.getString("schematicName");
+        if (fileConfiguration.contains("environment"))
+            this.environment = World.Environment.valueOf(fileConfiguration.getString("environment"));
+        this.protect = fileConfiguration.getBoolean("protect");
+        this.file = file;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean isEnabled) {
+        this.isEnabled = isEnabled;
+        fileConfiguration.set("isEnabled", isEnabled);
+        try {
+            fileConfiguration.save(file);
+        } catch (Exception ex) {
+            new WarningMessage("Failed to save dungeon state!");
+        }
+    }
+
+    public String getName() {
+        return ChatColorConverter.convert(name);
+    }
+
+    public DungeonLocationType getDungeonLocationType() {
+        return this.dungeonLocationType;
+    }
+
+    public List<String> getCustomInfo() {
+        return ChatColorConverter.convert(customInfo);
+    }
+
+    public List<String> getRelativeBossLocations() {
+        return relativeBossLocations;
+    }
+
+    public List<String> getRelativeTreasureChestLocations() {
+        return relativeTreasureChestLocations;
+    }
+
+    public String getDownloadLink() {
+        return downloadLink;
+    }
+
+    public DungeonSizeCategory getDungeonSizeCategory() {
+        return dungeonSizeCategory;
+    }
+
+    public String getWorldName() {
+        return ChatColorConverter.convert(worldName);
+    }
+
+    public String getSchematicName() {
+        return schematicName;
+    }
+
+    public World.Environment getEnvironment() {
+        return this.environment;
+    }
+
+    public boolean getProtect() {
+        return this.protect != null && this.protect;
+    }
+
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/ColosseumLair.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/ColosseumLair.java
@@ -1,0 +1,26 @@
+package com.magmaguy.elitemobs.config.dungeonpackager.premade;
+
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfigFields;
+
+import java.util.Arrays;
+
+public class ColosseumLair extends DungeonPackagerConfigFields {
+    public ColosseumLair() {
+        super("colosseum_lair",
+                true,
+                "&6The Colosseum",
+                DungeonLocationType.SCHEMATIC,
+                Arrays.asList("&fFeaturing the first true World boss, first",
+                        "&fmulti-phased battle, first mounted boss,",
+                        "&ffirst disguised boss... a truly epic fight!",
+                        "&6Credits: MagmaGuy & Maldini"),
+                Arrays.asList("colosseum_pit_master.yml:0,0,0,0,0"),
+                Arrays.asList(),
+                "patreon.com/magmaguy",
+                DungeonSizeCategory.LAIR,
+                null,
+                "elitemobs_colosseum.schem",
+                null,
+                null);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/DarkCathedralLair.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/DarkCathedralLair.java
@@ -1,0 +1,25 @@
+package com.magmaguy.elitemobs.config.dungeonpackager.premade;
+
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfigFields;
+
+import java.util.Arrays;
+
+public class DarkCathedralLair extends DungeonPackagerConfigFields {
+    public DarkCathedralLair() {
+        super("dark_cathedral_lair",
+                true,
+                "&8The Dark Cathedral",
+                DungeonLocationType.SCHEMATIC,
+                Arrays.asList("&fThe first ever EliteMobs Lair!",
+                        "&fA classic that all servers need!",
+                        "&6Credits: MagmaGuy & 69OzCanOfBepis"),
+                Arrays.asList("priest_of_cthulhu.yml:0,0,0,0,0"),
+                Arrays.asList(""),
+                "https://discord.gg/vRW9wXhK",
+                DungeonSizeCategory.LAIR,
+                null,
+                "elitemobs_dark_cathedral.schem",
+                null,
+                null);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/DarkSpireMinidungeon.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/DarkSpireMinidungeon.java
@@ -1,0 +1,26 @@
+package com.magmaguy.elitemobs.config.dungeonpackager.premade;
+
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfigFields;
+import org.bukkit.World;
+
+import java.util.Arrays;
+
+public class DarkSpireMinidungeon extends DungeonPackagerConfigFields {
+    public DarkSpireMinidungeon() {
+        super("dark_spire_lair",
+                true,
+                "&8The Dark Spire",
+                DungeonLocationType.WORLD,
+                Arrays.asList("&fThe first ever high level content!",
+                        "&fMade for those who want a real challenge!",
+                        "&6Credits: 69OzCanOfBepis"),
+                Arrays.asList(""),
+                Arrays.asList(""),
+                "patreon.com/magmaguy",
+                DungeonSizeCategory.MINIDUNGEON,
+                "elitemobs_hell_tower",
+                null,
+                World.Environment.NETHER,
+                true);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/HallosseumLair.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/HallosseumLair.java
@@ -1,0 +1,25 @@
+package com.magmaguy.elitemobs.config.dungeonpackager.premade;
+
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfigFields;
+import org.bukkit.World;
+
+import java.util.Arrays;
+
+public class HallosseumLair extends DungeonPackagerConfigFields {
+    public HallosseumLair() {
+        super("hallosseum_lair",
+                true,
+                "&fHallosseum",
+                DungeonLocationType.WORLD,
+                Arrays.asList("&fThe 2020 spooky halloween encounter!",
+                        "&6Credits: MagmaGuy & 69OzCanOfBepis"),
+                Arrays.asList(""),
+                Arrays.asList(""),
+                "https://discord.gg/vRW9wXhK",
+                DungeonSizeCategory.LAIR,
+                "hallosseum",
+                null,
+                World.Environment.NETHER,
+                true);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/SewersMinidungeon.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/premade/SewersMinidungeon.java
@@ -1,0 +1,25 @@
+package com.magmaguy.elitemobs.config.dungeonpackager.premade;
+
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfigFields;
+import org.bukkit.World;
+
+import java.util.Arrays;
+
+public class SewersMinidungeon extends DungeonPackagerConfigFields {
+    public SewersMinidungeon() {
+        super("sewers_minidungeon",
+                true,
+                "&8The Sewers",
+                DungeonLocationType.WORLD,
+                Arrays.asList("&fThe biggest minidungeon ever made!",
+                        "&6Credits: MagmaGuy & 69OzCanOfBepis"),
+                Arrays.asList(""),
+                Arrays.asList(""),
+                "https://discord.gg/vRW9wXhK",
+                DungeonSizeCategory.MINIDUNGEON,
+                "elitemobs_sewer_maze",
+                null,
+                World.Environment.NORMAL,
+                true);
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/dungeons/Minidungeon.java
+++ b/src/main/java/com/magmaguy/elitemobs/dungeons/Minidungeon.java
@@ -1,0 +1,206 @@
+package com.magmaguy.elitemobs.dungeons;
+
+import com.magmaguy.elitemobs.MetadataHandler;
+import com.magmaguy.elitemobs.config.custombosses.CustomBossConfigFields;
+import com.magmaguy.elitemobs.config.custombosses.CustomBossesConfig;
+import com.magmaguy.elitemobs.config.dungeonpackager.DungeonPackagerConfigFields;
+import com.magmaguy.elitemobs.dungeons.worlds.MinidungeonWorldLoader;
+import com.magmaguy.elitemobs.thirdparty.worldguard.WorldGuardCompatibility;
+import com.magmaguy.elitemobs.utils.DebugMessage;
+import com.magmaguy.elitemobs.utils.WarningMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class Minidungeon {
+
+    //Stores the filename and an instance of this object
+    public static HashMap<String, Minidungeon> minidungeons = new HashMap<>();
+
+    public boolean isDownloaded, isInstalled;
+    public DungeonPackagerConfigFields dungeonPackagerConfigFields;
+    public RelativeDungeonLocations relativeDungeonLocations;
+
+    public Minidungeon(DungeonPackagerConfigFields dungeonPackagerConfigFields) {
+        minidungeons.put(dungeonPackagerConfigFields.getFileName(), this);
+        this.dungeonPackagerConfigFields = dungeonPackagerConfigFields;
+        switch (dungeonPackagerConfigFields.getDungeonLocationType()) {
+            case WORLD:
+                setupWorldBasedMinidungeon();
+                break;
+            case SCHEMATIC:
+                setupSchematicBasedMinidungeon();
+                break;
+            default:
+                new WarningMessage("Mindungeon " + dungeonPackagerConfigFields.getFileName() + " does not have a valid dungeonLocationType! Valid types: schematic, world");
+                this.isDownloaded = this.isInstalled = false;
+                break;
+        }
+    }
+
+    private void setupWorldBasedMinidungeon() {
+        if (dungeonPackagerConfigFields.getWorldName() == null || dungeonPackagerConfigFields.getWorldName().isEmpty()) {
+            this.isDownloaded = this.isInstalled = false;
+            new WarningMessage("Minidungeon " + dungeonPackagerConfigFields.getFileName() + " does not have a valid world name in the dungeon packager!");
+            return;
+        }
+
+        //Check if the world's been loaded
+        if (Bukkit.getWorld(dungeonPackagerConfigFields.getWorldName()) != null) {
+            this.isDownloaded = this.isInstalled = true;
+            return;
+        }
+
+        //Since the world isn't loaded, there is no chance that the world is installed
+        this.isInstalled = false;
+
+        //Check if the world's been downloaded
+        isDownloaded = Files.exists(Bukkit.getWorldContainer().toPath());
+
+        if (isDownloaded && !isInstalled)
+            if (dungeonPackagerConfigFields.isEnabled())
+                MinidungeonWorldLoader.loadWorld(this);
+
+    }
+
+    private void setupSchematicBasedMinidungeon() {
+        this.isInstalled = false;
+
+        //If the configuration of the package is wrong
+        if (this.dungeonPackagerConfigFields.getSchematicName() == null || this.dungeonPackagerConfigFields.getSchematicName().isEmpty()) {
+            this.isDownloaded = false;
+            new WarningMessage("The minidungeon package " + this.dungeonPackagerConfigFields.getFileName() + " does not have a valid schematic file name!");
+        }
+
+        //If worldedit isn't installed, the checks can't be continued
+        if (!Bukkit.getPluginManager().isPluginEnabled("WorldEdit")) {
+            this.isDownloaded = false;
+            return;
+        }
+
+        try {
+
+            this.isDownloaded = Files.exists(Paths.get(MetadataHandler.PLUGIN.getDataFolder().getParentFile().getAbsolutePath()
+                    + "/WorldEdit/schematics/" + dungeonPackagerConfigFields.getSchematicName()));
+        } catch (Exception ex) {
+            this.isDownloaded = false;
+        }
+
+        this.relativeDungeonLocations = new RelativeDungeonLocations(dungeonPackagerConfigFields.getRelativeBossLocations());
+
+    }
+
+    public void commitLocation(Player player) {
+        this.relativeDungeonLocations.commitLocations(player);
+    }
+
+    public class RelativeDungeonLocations {
+        ArrayList<RelativeDungeonLocation> relativeDungeonLocations = new ArrayList<>();
+        public int bossCount = 0;
+
+        public RelativeDungeonLocations(List<String> rawStrings) {
+            for (String rawString : rawStrings) {
+                relativeDungeonLocations.add(new RelativeDungeonLocation(rawString));
+                bossCount++;
+            }
+        }
+
+        /**
+         * This runs when an admit tries to install a dungeon
+         *
+         * @param player
+         */
+        public void commitLocations(Player player) {
+            for (RelativeDungeonLocation relativeDungeonLocation : relativeDungeonLocations)
+                relativeDungeonLocation.customBossConfigFields.addSpawnLocation(player.getLocation().clone().add(relativeDungeonLocation.location));
+        }
+
+        public class RelativeDungeonLocation {
+            CustomBossConfigFields customBossConfigFields;
+            Location location;
+
+            public RelativeDungeonLocation(String rawLocationString) {
+                try {
+                    customBossConfigFields = CustomBossesConfig.getCustomBoss(rawLocationString.split(":")[0]);
+                    this.location = new Location(null,
+                            vectorGetter(rawLocationString, 0),
+                            vectorGetter(rawLocationString, 1),
+                            vectorGetter(rawLocationString, 2),
+                            (float) vectorGetter(rawLocationString, 3),
+                            (float) vectorGetter(rawLocationString, 4));
+                } catch (Exception ex) {
+                    new DebugMessage("Failed to generate dungeon from raw " + rawLocationString);
+                    ex.printStackTrace();
+                }
+            }
+
+            private double vectorGetter(String rawLocationString, int position) {
+                return Double.parseDouble(rawLocationString.split(":")[1].split(",")[position]);
+            }
+        }
+    }
+
+    public void buttonToggleBehavior(Player player) {
+        switch (this.dungeonPackagerConfigFields.getDungeonLocationType()) {
+            case WORLD:
+                worldButtonToggleBehavior(player);
+                break;
+            case SCHEMATIC:
+                schematicButtonToggleBehavior(player);
+                break;
+        }
+    }
+
+    private void worldButtonToggleBehavior(Player player) {
+        World world = Bukkit.getWorld(dungeonPackagerConfigFields.getWorldName());
+        if (world == null) {
+            dungeonPackagerConfigFields.setEnabled(true);
+            loadWorld(player);
+        } else {
+            dungeonPackagerConfigFields.setEnabled(false);
+            unloadWorld(player);
+        }
+    }
+
+    private void loadWorld(Player player) {
+        try {
+            World world = MinidungeonWorldLoader.runtimeLoadWorld(this);
+            WorldGuardCompatibility.protectWorldMinidugeonArea(world.getSpawnLocation());
+            player.teleport(world.getSpawnLocation());
+            player.sendMessage("Minidungeon " + dungeonPackagerConfigFields.getWorldName() +
+                    " has been loaded! The world is now loaded and the regional bosses are up.");
+            isInstalled = true;
+        } catch (Exception exception) {
+            player.sendMessage("Warning: Failed to load the " + dungeonPackagerConfigFields.getWorldName() + " world!");
+        }
+    }
+
+    private void unloadWorld(Player player) {
+        try {
+            for (Player iteratedPlayer : Bukkit.getOnlinePlayers())
+                if (iteratedPlayer.getWorld().getName().equals(dungeonPackagerConfigFields.getWorldName())) {
+                    player.sendMessage("[EliteMobs] Failed to unload Minidungeon because at least one player is in the world "
+                            + dungeonPackagerConfigFields.getWorldName());
+                    return;
+                }
+            MinidungeonWorldLoader.unloadWorld(this);
+            player.sendMessage("Minidugeon " + dungeonPackagerConfigFields.getWorldName() +
+                    " has been unloaded! The world is now unloaded. The world is now unloaded and the regional bosses are down.");
+            isInstalled = false;
+        } catch (Exception exception) {
+            player.sendMessage("Warning: Failed to unload the " + dungeonPackagerConfigFields.getWorldName() + " world!");
+        }
+    }
+
+    private void schematicButtonToggleBehavior(Player player) {
+        player.sendMessage("This feature is harder to implement, it will be ready in a few days!");
+    }
+
+}

--- a/src/main/java/com/magmaguy/elitemobs/dungeons/worlds/MinidungeonWorldLoader.java
+++ b/src/main/java/com/magmaguy/elitemobs/dungeons/worlds/MinidungeonWorldLoader.java
@@ -1,0 +1,58 @@
+package com.magmaguy.elitemobs.dungeons.worlds;
+
+import com.magmaguy.elitemobs.EliteMobs;
+import com.magmaguy.elitemobs.dungeons.Minidungeon;
+import com.magmaguy.elitemobs.mobconstructor.custombosses.RegionalBossEntity;
+import com.magmaguy.elitemobs.thirdparty.worldguard.WorldGuardCompatibility;
+import com.magmaguy.elitemobs.utils.ConfigurationLocation;
+import com.magmaguy.elitemobs.utils.InfoMessage;
+import com.magmaguy.elitemobs.utils.WarningMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class MinidungeonWorldLoader {
+    public static World loadWorld(Minidungeon minidungeon) {
+        File folder = new File(Bukkit.getWorldContainer().getAbsolutePath());
+
+        new InfoMessage("Trying to load Minidungeon world " + minidungeon.dungeonPackagerConfigFields.getWorldName());
+        if (!Files.exists(Paths.get(folder.getAbsolutePath() + "/" + minidungeon.dungeonPackagerConfigFields.getWorldName())))
+            return null;
+        new InfoMessage("Detected Minidungeon world " + minidungeon.dungeonPackagerConfigFields.getWorldName());
+        try {
+            WorldCreator worldCreator = new WorldCreator(minidungeon.dungeonPackagerConfigFields.getWorldName());
+            worldCreator.environment(minidungeon.dungeonPackagerConfigFields.getEnvironment());
+            World world = Bukkit.createWorld(worldCreator);
+            if (world != null)
+                world.setKeepSpawnInMemory(false);
+            new InfoMessage("Minidungeons world " + minidungeon.dungeonPackagerConfigFields.getWorldName() + " was loaded successfully!");
+            minidungeon.isInstalled = true;
+            if (EliteMobs.worldguardIsEnabled && minidungeon.dungeonPackagerConfigFields.getProtect())
+                WorldGuardCompatibility.protectWorldMinidugeonArea(world.getSpawnLocation());
+            return world;
+        } catch (Exception exception) {
+            new WarningMessage("Failed to load Minidungeon world " + minidungeon.dungeonPackagerConfigFields.getWorldName() + " !");
+        }
+
+        return null;
+    }
+
+    public static void unloadWorld(Minidungeon minidungeon) {
+        Bukkit.unloadWorld(minidungeon.dungeonPackagerConfigFields.getWorldName(), true);
+    }
+
+    public static World runtimeLoadWorld(Minidungeon minidungeon) {
+        World world = loadWorld(minidungeon);
+        if (world == null) return null;
+        for (RegionalBossEntity regionalBossEntity : RegionalBossEntity.getRegionalBossEntityList())
+            if (regionalBossEntity.getSpawnWorldName().equals(world.getName())) {
+                regionalBossEntity.spawnLocation = ConfigurationLocation.deserialize(regionalBossEntity.spawnLocationString);
+                regionalBossEntity.spawnRegionalBoss();
+            }
+        return world;
+    }
+}

--- a/src/main/java/com/magmaguy/elitemobs/items/LootTables.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/LootTables.java
@@ -245,9 +245,11 @@ public class LootTables implements Listener {
             } catch (NullPointerException ex) {
                 new DebugMessage("Error generating loot");
                 new DebugMessage("totalweight: " + totalWeight);
-                new DebugMessage("itemStack is null: " + itemStack == null);
-                new DebugMessage("weighed items list is null:" + CustomItem.getWeighedFixedItems() == null);
-                new DebugMessage("Weight value is null: " + CustomItem.getWeighedFixedItems().get(itemStack) == null);
+                new DebugMessage("itemStack is null: " + (itemStack == null));
+                if (itemStack != null)
+                    new DebugMessage("itemStack is " + itemStack.getItemMeta().getDisplayName());
+                new DebugMessage("weighed items list is null:" + (CustomItem.getWeighedFixedItems() == null));
+                new DebugMessage("Weight value is null: " + (CustomItem.getWeighedFixedItems().get(itemStack) == null));
                 ex.printStackTrace();
             }
 

--- a/src/main/java/com/magmaguy/elitemobs/items/customenchantments/SoulbindEnchantment.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customenchantments/SoulbindEnchantment.java
@@ -101,7 +101,7 @@ public class SoulbindEnchantment extends CustomEnchantment {
         else if ((itemMeta.getPersistentDataContainer().get(new NamespacedKey(MetadataHandler.PLUGIN, key), PersistentDataType.STRING)).equals(player.getUniqueId().toString() + GuildRank.getGuildPrestigeRank(player)))
             return true;
         else
-            return getPrestigeLevel(itemMeta) == GuildRank.getGuildPrestigeRank(player);
+            return getPrestigeLevel(itemMeta) == GuildRank.getGuildPrestigeRank(player) && itemMeta.getPersistentDataContainer().get(new NamespacedKey(MetadataHandler.PLUGIN, key), PersistentDataType.STRING).equals(player.getUniqueId().toString());
     }
 
     public static Player getSoulboundPlayer(ItemMeta itemMeta) {

--- a/src/main/java/com/magmaguy/elitemobs/items/customitems/CustomItem.java
+++ b/src/main/java/com/magmaguy/elitemobs/items/customitems/CustomItem.java
@@ -8,7 +8,6 @@ import com.magmaguy.elitemobs.items.LootTables;
 import com.magmaguy.elitemobs.items.ScalableItemConstructor;
 import com.magmaguy.elitemobs.items.customenchantments.*;
 import com.magmaguy.elitemobs.items.itemconstructor.ItemConstructor;
-import com.magmaguy.elitemobs.utils.DebugMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -117,7 +116,6 @@ public class CustomItem {
     // Adds weighed static items
     private static void addWeighedFixedItems(CustomItem customItem) {
         ItemStack itemStack = customItem.generateDefaultsItemStack(null, false);
-        if (itemStack == null) new DebugMessage("Warning: null for " + customItem.getFileName());
         weighedFixedItems.put(itemStack, customItem.getDropWeight());
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/RegionalBossEntity.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/RegionalBossEntity.java
@@ -29,7 +29,8 @@ public class RegionalBossEntity implements Listener {
     public CustomBossEntity customBossEntity;
     private final CustomBossConfigFields.ConfigRegionalEntity configRegionalEntity;
     public boolean isAlive;
-    private final Location spawnLocation;
+    public Location spawnLocation;
+    public final String spawnLocationString;
     private double leashRadius;
     private final int respawnCooldown;
     public boolean inCooldown = false;
@@ -38,19 +39,20 @@ public class RegionalBossEntity implements Listener {
     public RegionalBossEntity(CustomBossConfigFields customBossConfigFields, CustomBossConfigFields.ConfigRegionalEntity configRegionalEntity) {
         this.configRegionalEntity = configRegionalEntity;
         this.spawnLocation = configRegionalEntity.spawnLocation;
+        this.spawnLocationString = configRegionalEntity.spawnLocationString;
         this.respawnCooldown = customBossConfigFields.getSpawnCooldown();
         this.customBossConfigFields = customBossConfigFields;
         this.leashRadius = customBossConfigFields.getLeashRadius();
+        regionalBossEntityList.add(this);
         if (spawnLocation == null || spawnLocation.getWorld() == null) {
             new WarningMessage("Spawn location for regional boss " + customBossConfigFields.getFileName() + " is not valid. Incorrect location: " + spawnLocation);
             new WarningMessage("EliteMobs will skip this entity's spawn.");
             return;
         }
         spawnRegionalBoss();
-        regionalBossEntityList.add(this);
     }
 
-    private void spawnRegionalBoss() {
+    public void spawnRegionalBoss() {
 
         EntityType entityType;
 
@@ -187,6 +189,15 @@ public class RegionalBossEntity implements Listener {
             }
 
         }.runTaskTimerAsynchronously(MetadataHandler.PLUGIN, 20, 20 * 60);
+    }
+
+    public void hardDelete() {
+        customBossConfigFields.removeSpawnLocation(configRegionalEntity);
+        regionalBossEntityList.remove(this);
+    }
+
+    public String getSpawnWorldName() {
+        return this.spawnLocationString.split(",")[0];
     }
 
     public CustomBossConfigFields getCustomBossConfigFields() {

--- a/src/main/java/com/magmaguy/elitemobs/npcs/NPCEntity.java
+++ b/src/main/java/com/magmaguy/elitemobs/npcs/NPCEntity.java
@@ -150,6 +150,10 @@ public class NPCEntity {
             this.spawnLocation = location.clone();
         this.spawnLocation.setDirection(this.spawnLocation.getDirection().multiply(-1));
 
+        //this is how the wandering trader works
+        if (npCsConfigFields.getLocation().equalsIgnoreCase("null"))
+            return;
+
         WorldGuardSpawnEventBypasser.forceSpawn();
         try {
             this.villager = (Villager) spawnLocation.getWorld().spawnEntity(spawnLocation, EntityType.VILLAGER);

--- a/src/main/java/com/magmaguy/elitemobs/powers/majorpowers/zombie/ZombieFriends.java
+++ b/src/main/java/com/magmaguy/elitemobs/powers/majorpowers/zombie/ZombieFriends.java
@@ -54,8 +54,8 @@ public class ZombieFriends extends MajorPower implements Listener {
 
                         nameClearer(reinforcement2);
 
-                        reinforcement2.getLivingEntity().setCustomName(ChatColorConverter.convert(PowersConfig.getPower("zombie_friends.yml").getConfiguration().getStringList("DeathMessage").
-                                get(ThreadLocalRandom.current().nextInt(PowersConfig.getPower("zombie_friends.yml").getConfiguration().getStringList("DeathMessage")
+                        reinforcement2.getLivingEntity().setCustomName(ChatColorConverter.convert(PowersConfig.getPower("zombie_friends.yml").getConfiguration().getStringList("friendDeathMessage").
+                                get(ThreadLocalRandom.current().nextInt(PowersConfig.getPower("zombie_friends.yml").getConfiguration().getStringList("friendDeathMessage")
                                         .size()))));
 
                     }

--- a/src/main/java/com/magmaguy/elitemobs/powerstances/GenericRotationMatrixMath.java
+++ b/src/main/java/com/magmaguy/elitemobs/powerstances/GenericRotationMatrixMath.java
@@ -1,5 +1,6 @@
 package com.magmaguy.elitemobs.powerstances;
 
+import org.bukkit.Location;
 import org.bukkit.util.Vector;
 
 import static java.lang.Math.*;
@@ -45,10 +46,6 @@ public class GenericRotationMatrixMath {
         it easier to predict where things are supposed to be.
     */
 
-    //TODO: register points in hashmap <int, List<Location>>
-    private static Vector newVector;
-    private static double newX, newY, newZ;
-
     public static Vector applyRotation(double a, double b, double c, double numberOfPointsPerFullRotation, double x, double y, double z, int counter) {
 
         double theta;
@@ -58,15 +55,33 @@ public class GenericRotationMatrixMath {
         //Get the next rotation
         theta = theta + theta * counter;
 
-        newX = x * (cos(theta) + (1 - cos(theta)) * pow(a, 2)) + y * ((1 - cos(theta)) * a * b + (sin(theta)) * c) + z * ((1 - cos(theta)) * a * c - (sin(theta)) * b);
-        newY = x * ((1 - cos(theta)) * b * a - (sin(theta)) * c) + y * (cos(theta) + (1 - cos(theta)) * pow(b, 2)) + z * ((1 - cos(theta)) * b * c + (sin(theta)) * a);
-        newZ = x * ((1 - cos(theta)) * c * a + (sin(theta)) * b) + y * ((1 - cos(theta)) * c * b - (sin(theta)) * a) + z * (cos(theta) + (1 - cos(theta)) * pow(c, 2));
+        double newX = x * (cos(theta) + (1 - cos(theta)) * pow(a, 2)) + y * ((1 - cos(theta)) * a * b + (sin(theta)) * c) + z * ((1 - cos(theta)) * a * c - (sin(theta)) * b);
+        double newY = x * ((1 - cos(theta)) * b * a - (sin(theta)) * c) + y * (cos(theta) + (1 - cos(theta)) * pow(b, 2)) + z * ((1 - cos(theta)) * b * c + (sin(theta)) * a);
+        double newZ = x * ((1 - cos(theta)) * c * a + (sin(theta)) * b) + y * ((1 - cos(theta)) * c * b - (sin(theta)) * a) + z * (cos(theta) + (1 - cos(theta)) * pow(c, 2));
 
         //adjust rotated point
-        newVector = new Vector(newX, newY, newZ);
+        Vector newVector = new Vector(newX, newY, newZ);
 
         return newVector;
 
+    }
+
+    private static Location rotateSpecificLocation(double a, double b, double c, double theta, Location location) {
+        double x = location.getX();
+        double y = location.getY();
+        double z = location.getZ();
+        //Convert radian to degree
+        theta *= 180 / PI;
+
+        double newX = x * (cos(theta) + (1 - cos(theta)) * pow(a, 2)) + y * ((1 - cos(theta)) * a * b + (sin(theta)) * c) + z * ((1 - cos(theta)) * a * c - (sin(theta)) * b);
+        double newY = x * ((1 - cos(theta)) * b * a - (sin(theta)) * c) + y * (cos(theta) + (1 - cos(theta)) * pow(b, 2)) + z * ((1 - cos(theta)) * b * c + (sin(theta)) * a);
+        double newZ = x * ((1 - cos(theta)) * c * a + (sin(theta)) * b) + y * ((1 - cos(theta)) * c * b - (sin(theta)) * a) + z * (cos(theta) + (1 - cos(theta)) * pow(c, 2));
+
+        return new Location(location.getWorld(), newX, newY, newZ);
+    }
+
+    public static Location rotateLocationYAxis(double rotationAngleInDegrees, Location location) {
+        return rotateSpecificLocation(0, 1, 0, rotationAngleInDegrees, location);
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/thirdparty/worldguard/WorldGuardCompatibility.java
+++ b/src/main/java/com/magmaguy/elitemobs/thirdparty/worldguard/WorldGuardCompatibility.java
@@ -1,12 +1,19 @@
 package com.magmaguy.elitemobs.thirdparty.worldguard;
 
 import com.magmaguy.elitemobs.utils.WarningMessage;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.IntegerFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 
 public class WorldGuardCompatibility {
 
@@ -115,6 +122,68 @@ public class WorldGuardCompatibility {
 
     public static final IntegerFlag getEliteMobsMaximumLevel() {
         return ELITEMOBS_MAXIMUM_LEVEL;
+    }
+
+    private static final StateFlag.State allow = StateFlag.State.ALLOW;
+    private static final StateFlag.State deny = StateFlag.State.DENY;
+
+    public static void protectWorldMinidugeonArea(Location location) {
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionManager regions = container.get(BukkitAdapter.adapt(location.getWorld()));
+        ProtectedRegion global = regions.getRegion("__global__");
+
+        if (global == null) {
+            // But we want a __global__, so let's create one
+            global = new GlobalProtectedRegion("__global__");
+            regions.addRegion(global);
+        }
+
+        protectMinidungeonArea(global);
+
+    }
+
+    public static void protectMinidungeonArea(ProtectedRegion protectedRegion) {
+        protectedRegion.setFlag(ELITEMOBS_DUNGEON, allow);
+        protectedRegion.setFlag(ELITEMOBS_ANTIEXPLOIT, deny);
+        protectedRegion.setFlag(Flags.INTERACT, deny);
+        protectedRegion.setFlag(Flags.CREEPER_EXPLOSION, deny);
+        protectedRegion.setFlag(Flags.FIRE_SPREAD, deny);
+        protectedRegion.setFlag(Flags.LAVA_FIRE, deny);
+        protectedRegion.setFlag(Flags.LAVA_FLOW, deny);
+        protectedRegion.setFlag(Flags.SNOW_FALL, deny);
+        protectedRegion.setFlag(Flags.SNOW_MELT, deny);
+        protectedRegion.setFlag(Flags.ICE_FORM, deny);
+        protectedRegion.setFlag(Flags.ICE_MELT, deny);
+        protectedRegion.setFlag(Flags.FROSTED_ICE_FORM, deny);
+        protectedRegion.setFlag(Flags.FROSTED_ICE_MELT, deny);
+        protectedRegion.setFlag(Flags.LEAF_DECAY, deny);
+        protectedRegion.setFlag(Flags.GRASS_SPREAD, deny);
+        protectedRegion.setFlag(Flags.MYCELIUM_SPREAD, deny);
+        protectedRegion.setFlag(Flags.CROP_GROWTH, deny);
+        protectedRegion.setFlag(Flags.SOIL_DRY, deny);
+        //missing coral-fade
+        //missing ravager-grief
+        protectedRegion.setFlag(Flags.GHAST_FIREBALL, deny);
+        protectedRegion.setFlag(Flags.WITHER_DAMAGE, deny);
+        protectedRegion.setFlag(Flags.ENDER_BUILD, deny);
+        protectedRegion.setFlag(Flags.ITEM_FRAME_ROTATE, deny);
+        protectedRegion.setFlag(Flags.PLACE_VEHICLE, deny);
+        protectedRegion.setFlag(Flags.DESTROY_VEHICLE, deny);
+        protectedRegion.setFlag(Flags.PVP, deny);
+        protectedRegion.setFlag(Flags.OTHER_EXPLOSION, deny);
+        protectedRegion.setFlag(Flags.TRAMPLE_BLOCKS, deny);
+        protectedRegion.setFlag(Flags.VINE_GROWTH, deny);
+        protectedRegion.setFlag(Flags.MUSHROOMS, deny);
+        protectedRegion.setFlag(Flags.DAMAGE_ANIMALS, allow);
+        protectedRegion.setFlag(Flags.SLEEP, deny);
+        protectedRegion.setFlag(Flags.CHEST_ACCESS, allow);
+        protectedRegion.setFlag(Flags.ENTITY_ITEM_FRAME_DESTROY, deny);
+        protectedRegion.setFlag(Flags.ENTITY_PAINTING_DESTROY, deny);
+        protectedRegion.setFlag(Flags.MOB_SPAWNING, allow);
+        protectedRegion.setFlag(Flags.TNT, deny);
+        protectedRegion.setFlag(Flags.ENDERDRAGON_BLOCK_DAMAGE, deny);
+        protectedRegion.setFlag(Flags.LIGHTER, deny);
+        protectedRegion.setFlag(Flags.ENDERPEARL, deny);
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/utils/ConfigurationLocation.java
+++ b/src/main/java/com/magmaguy/elitemobs/utils/ConfigurationLocation.java
@@ -36,6 +36,8 @@ public class ConfigurationLocation {
             yaw = Float.parseFloat(getSubString(locationOnlyString, 4, ","));
             pitch = Float.parseFloat(getSubString(locationOnlyString, 5, ","));
         } catch (Exception ex) {
+            if (locationString == null || locationString.equals("null"))
+                return null;
             new WarningMessage("Attempted to deserialize an invalid location!");
             new WarningMessage("Expected location format: worldname,x,y,z,pitch,yaw");
             new WarningMessage("Real location format: " + locationString);

--- a/src/main/java/com/magmaguy/elitemobs/worlds/CustomWorldLoading.java
+++ b/src/main/java/com/magmaguy/elitemobs/worlds/CustomWorldLoading.java
@@ -2,6 +2,7 @@ package com.magmaguy.elitemobs.worlds;
 
 import com.magmaguy.elitemobs.config.AdventurersGuildConfig;
 import com.magmaguy.elitemobs.utils.InfoMessage;
+import com.magmaguy.elitemobs.utils.WarningMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.WorldCreator;
 
@@ -17,8 +18,14 @@ public class CustomWorldLoading {
             if (listOfFile.isDirectory() &&
                     listOfFile.getName().equals(AdventurersGuildConfig.guildWorldName)) {
                 new InfoMessage("[EliteMobs] World " + AdventurersGuildConfig.guildWorldName + " found! Loading it in...");
-                Bukkit.createWorld(new WorldCreator(AdventurersGuildConfig.guildWorldName));
-                new InfoMessage("[EliteMobs] World " + AdventurersGuildConfig.guildWorldName + " has been successfully loaded! It can be accessed through the '/ag' command, unless you changed that config option!");
+                try {
+                    WorldCreator worldCreator = new WorldCreator(AdventurersGuildConfig.guildWorldName);
+                    Bukkit.createWorld(worldCreator).setKeepSpawnInMemory(false);
+                    new InfoMessage("[EliteMobs] World " + AdventurersGuildConfig.guildWorldName + " has been successfully loaded! It can be accessed through the '/ag' command, unless you changed that config option!");
+                } catch (Exception ex) {
+                    new WarningMessage("Failed to generate Adventurer's Guild World!");
+                    ex.printStackTrace();
+                }
                 break;
             }
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EliteMobs
-version: 7.2.8
+version: 7.2.9
 author: MagmaGuy
 main: com.magmaguy.elitemobs.EliteMobs
 api-version: 1.14


### PR DESCRIPTION
- [New] Added the DungeonPackager system
- [New] Added the dungeonpackages config directory & default configs
- [New] Added the /em setup menu
- [New] Minidungeons with their own dedicated worlds are now automatically loaded by default by EliteMobs
- [New] Minidungeon/Adventurer's guild worlds now stay fully unloaded when not in use, drastically improving the performance of some server setups
- [New] Minidungeon world loaded by EliteMobs automatically get all of their flags applied on load by default
- [New] Minidungeon worlds can now be toggled on and off via the /em setup menu
- [HOTFIX] Fixes issue where soulbound wasn't applying correctly under some conditions
- [Fix] Wandering traveller no longer sends warning messages about not having a set location
- [Fix] Fixed ZombieFriends error
- [Tweak] Scalable items now construct secondary enchantments based off of the set maximum item enchantment levels

Signed-off-by: MagmaGuy <tiagoarnaut@gmail.com>