### PR TITLE
Version 7.2.10

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.magmaguy</groupId>
-    <artifactId>EliteMobs</artifactId>
-    <version>7.2.9</version>
-    <build>
-        <defaultGoal>clean resources:resources package</defaultGoal>
-        <finalName>${project.artifactId}</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.magmaguy</groupId>
+  <artifactId>EliteMobs</artifactId>
+  <version>7.2.10</version>
+  <build>
+    <defaultGoal>clean resources:resources package</defaultGoal>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.2</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
           <execution>
             <phase>package</phase>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.magmaguy</groupId>
     <artifactId>EliteMobs</artifactId>
-    <version>7.2.9</version>
+    <version>7.2.10</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/magmaguy/elitemobs/EliteMobs.java
+++ b/src/main/java/com/magmaguy/elitemobs/EliteMobs.java
@@ -165,11 +165,6 @@ public class EliteMobs extends JavaPlugin {
         //QuestRefresher.generateNewQuestMenus();
 
         /*
-        Spawn world bosses
-         */
-        RegionalBossHandler.initialize();
-
-        /*
         Initialize NPCs
          */
         new NPCInitializer();
@@ -257,6 +252,10 @@ public class EliteMobs extends JavaPlugin {
         CommandsConfig.initializeConfigs();
         EventsConfig.initializeConfigs();
         DiscordSRVConfig.initializeConfig();
+        /*
+        Spawn world bosses
+         */
+        RegionalBossHandler.initialize();
         DungeonPackagerConfig.initializeConfigs();
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/adventurersguild/GuildRank.java
+++ b/src/main/java/com/magmaguy/elitemobs/adventurersguild/GuildRank.java
@@ -1,5 +1,6 @@
 package com.magmaguy.elitemobs.adventurersguild;
 
+import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.config.AdventurersGuildConfig;
 import com.magmaguy.elitemobs.playerdata.PlayerData;
 import com.magmaguy.elitemobs.utils.Round;
@@ -8,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class GuildRank {
 
@@ -213,8 +215,15 @@ public class GuildRank {
 
     public static class GuildRankEvents implements Listener {
         @EventHandler
-        public void onPlayerLogin(PlayerJoinEvent event) {
-            setMaxHealth(event.getPlayer(), GuildRank.getActiveGuildRank(event.getPlayer()), GuildRank.getGuildPrestigeRank(event.getPlayer()));
+        public void onPlayerJoin(PlayerJoinEvent event) {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    setMaxHealth(event.getPlayer(),
+                            GuildRank.getActiveGuildRank(event.getPlayer(), true),
+                            GuildRank.getGuildPrestigeRank(event.getPlayer(), true));
+                }
+            }.runTaskLater(MetadataHandler.PLUGIN, 20 * 3);
         }
     }
 

--- a/src/main/java/com/magmaguy/elitemobs/config/ConfigurationEngine.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/ConfigurationEngine.java
@@ -2,6 +2,7 @@ package com.magmaguy.elitemobs.config;
 
 import com.magmaguy.elitemobs.ChatColorConverter;
 import com.magmaguy.elitemobs.MetadataHandler;
+import com.magmaguy.elitemobs.utils.WarningMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -86,6 +87,19 @@ public class ConfigurationEngine {
     public static List setList(FileConfiguration fileConfiguration, String key, List defaultValue) {
         fileConfiguration.addDefault(key, defaultValue);
         return fileConfiguration.getList(key);
+    }
+
+    public static void writeValue(Object value, File file, FileConfiguration fileConfiguration, String path) {
+        fileConfiguration.set(path, value);
+        try {
+            fileSaverCustomValues(fileConfiguration, file);
+        } catch (Exception exception) {
+            new WarningMessage("Failed to write value for " + path + " in file " + file.getName());
+        }
+    }
+
+    public static void removeValue(File file, FileConfiguration fileConfiguration, String path) {
+        writeValue(null, file, fileConfiguration, path);
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/config/custombosses/CustomBossConfigFields.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/custombosses/CustomBossConfigFields.java
@@ -2,6 +2,7 @@ package com.magmaguy.elitemobs.config.custombosses;
 
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.config.ConfigurationEngine;
+import com.magmaguy.elitemobs.mobconstructor.custombosses.RegionalBossEntity;
 import com.magmaguy.elitemobs.utils.ConfigurationLocation;
 import com.magmaguy.elitemobs.utils.ItemStackGenerator;
 import com.magmaguy.elitemobs.utils.WarningMessage;
@@ -568,9 +569,10 @@ public class CustomBossConfigFields {
     public ConfigRegionalEntity addSpawnLocation(Location location) {
         ConfigRegionalEntity newConfigRegionalEntity = new ConfigRegionalEntity(location, ConfigurationLocation.serialize(location), 0);
         configRegionalEntities.put(newConfigRegionalEntity.uuid, newConfigRegionalEntity);
+        new RegionalBossEntity(this, newConfigRegionalEntity);
         List<String> convertedList = new ArrayList<>();
         for (ConfigRegionalEntity configRegionalEntity : configRegionalEntities.values())
-            convertedList.add(ConfigurationLocation.serialize(configRegionalEntity.spawnLocation) + ":" + configRegionalEntity.respawnTimeLeft);
+            convertedList.add(configRegionalEntity.spawnLocationString);
         fileConfiguration.set("spawnLocations", convertedList);
         try {
             fileConfiguration.save(file);
@@ -585,12 +587,15 @@ public class CustomBossConfigFields {
         List<String> convertedList = new ArrayList<>();
         for (ConfigRegionalEntity iteratedConfigRegionalEntity : configRegionalEntities.values())
             convertedList.add(ConfigurationLocation.serialize(iteratedConfigRegionalEntity.spawnLocation) + ":" + iteratedConfigRegionalEntity.respawnTimeLeft);
-        fileConfiguration.set("spawnLocations", convertedList);
-        try {
-            fileConfiguration.save(file);
-        } catch (IOException ex) {
-            new WarningMessage("Failed to save new boss location! It will not show up in the right place after a restart. Report this to the dev.");
+        for (Iterator<RegionalBossEntity> regionalBossEntityIterator = RegionalBossEntity.getRegionalBossEntityList().iterator(); regionalBossEntityIterator.hasNext(); ) {
+            RegionalBossEntity regionalBossEntity = regionalBossEntityIterator.next();
+            if (regionalBossEntity.configRegionalEntity.equals(configRegionalEntity)) {
+                regionalBossEntity.softDelete();
+                regionalBossEntityIterator.remove();
+            }
+
         }
+        ConfigurationEngine.writeValue(convertedList, file, fileConfiguration, "spawnLocations");
     }
 
     public void setLeashRadius(double leashRadius) {

--- a/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/DungeonPackagerConfigFields.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/dungeonpackager/DungeonPackagerConfigFields.java
@@ -1,7 +1,10 @@
 package com.magmaguy.elitemobs.config.dungeonpackager;
 
 import com.magmaguy.elitemobs.ChatColorConverter;
+import com.magmaguy.elitemobs.config.ConfigurationEngine;
+import com.magmaguy.elitemobs.utils.ConfigurationLocation;
 import com.magmaguy.elitemobs.utils.WarningMessage;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
 
@@ -37,6 +40,8 @@ public class DungeonPackagerConfigFields {
     private World.Environment environment;
     private final Boolean protect;
     private File file;
+    private Location anchorPoint;
+    private double rotation;
 
     public DungeonPackagerConfigFields(String fileName,
                                        boolean isEnabled,
@@ -82,9 +87,11 @@ public class DungeonPackagerConfigFields {
             fileConfiguration.addDefault("environment", environment.toString());
         if (protect != null)
             fileConfiguration.addDefault("protect", protect);
+        fileConfiguration.addDefault("rotation", 0);
     }
 
     public DungeonPackagerConfigFields(FileConfiguration fileConfiguration, File file) {
+        this.file = file;
         this.fileName = file.getName();
         this.fileConfiguration = fileConfiguration;
         this.isEnabled = fileConfiguration.getBoolean("isEnabled");
@@ -108,7 +115,10 @@ public class DungeonPackagerConfigFields {
         if (fileConfiguration.contains("environment"))
             this.environment = World.Environment.valueOf(fileConfiguration.getString("environment"));
         this.protect = fileConfiguration.getBoolean("protect");
-        this.file = file;
+        if (fileConfiguration.contains("anchorPoint"))
+            this.anchorPoint = ConfigurationLocation.deserialize(fileConfiguration.getString("anchorPoint"));
+        if (fileConfiguration.contains("rotation"))
+            this.rotation = fileConfiguration.getDouble("rotation");
     }
 
     public String getFileName() {
@@ -121,12 +131,15 @@ public class DungeonPackagerConfigFields {
 
     public void setEnabled(boolean isEnabled) {
         this.isEnabled = isEnabled;
-        fileConfiguration.set("isEnabled", isEnabled);
-        try {
-            fileConfiguration.save(file);
-        } catch (Exception ex) {
-            new WarningMessage("Failed to save dungeon state!");
-        }
+        ConfigurationEngine.writeValue(isEnabled, file, fileConfiguration, "isEnabled");
+    }
+
+    public void setEnabled(boolean isEnabled, Location anchorPoint) {
+        setEnabled(isEnabled);
+        if (isEnabled)
+            setAnchorPoint(anchorPoint);
+        else
+            removeAnchorPoint();
     }
 
     public String getName() {
@@ -171,6 +184,29 @@ public class DungeonPackagerConfigFields {
 
     public boolean getProtect() {
         return this.protect != null && this.protect;
+    }
+
+    public Location getAnchorPoint() {
+        return this.anchorPoint;
+    }
+
+    private void setAnchorPoint(Location location) {
+        this.anchorPoint = location;
+        ConfigurationEngine.writeValue(ConfigurationLocation.serialize(location), file, fileConfiguration, "anchorPoint");
+    }
+
+    private void removeAnchorPoint() {
+        ConfigurationEngine.removeValue(file, fileConfiguration, "anchorPoint");
+        this.anchorPoint = null;
+    }
+
+    public double getRotation() {
+        return this.rotation;
+    }
+
+    public void setRotation(double rotation) {
+        this.rotation = rotation;
+        ConfigurationEngine.writeValue(rotation, file, fileConfiguration, "rotation");
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/config/potioneffects/PotionEffectsConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/potioneffects/PotionEffectsConfig.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 
 public class PotionEffectsConfig {
 
-    private static HashMap<String, PotionEffectsConfigFields> potionEffects = new HashMap();
+    private static final HashMap<String, PotionEffectsConfigFields> potionEffects = new HashMap();
 
     public static void addPotionEffect(String fileName, PotionEffectsConfigFields powersConfigFields) {
         potionEffects.put(fileName, powersConfigFields);
@@ -24,10 +24,10 @@ public class PotionEffectsConfig {
         return potionEffects.get(fileName);
     }
 
-    private static ArrayList<PotionEffectsConfigFields> potionEffectsConfigFields = new ArrayList<>(Arrays.asList(
+    private static final ArrayList<PotionEffectsConfigFields> potionEffectsConfigFields = new ArrayList<>(Arrays.asList(
             new AbsorptionConfig(),
             new BlindnessConfig(),
-            new ConduitConfig(),
+            new ConduitPowerConfig(),
             new ConfusionConfig(),
             new DamageResistanceConfig(),
             new DolphinsGraceConfig(),

--- a/src/main/java/com/magmaguy/elitemobs/config/potioneffects/premade/ConduitPowerConfig.java
+++ b/src/main/java/com/magmaguy/elitemobs/config/potioneffects/premade/ConduitPowerConfig.java
@@ -2,9 +2,9 @@ package com.magmaguy.elitemobs.config.potioneffects.premade;
 
 import com.magmaguy.elitemobs.config.potioneffects.PotionEffectsConfigFields;
 
-public class ConduitConfig extends PotionEffectsConfigFields {
-    public ConduitConfig() {
-        super("conduit",
+public class ConduitPowerConfig extends PotionEffectsConfigFields {
+    public ConduitPowerConfig() {
+        super("conduit_power",
                 true,
                 "Conduit Power",
                 30,

--- a/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/CustomBossEntity.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobconstructor/custombosses/CustomBossEntity.java
@@ -473,6 +473,8 @@ public class CustomBossEntity extends EliteMobEntity implements Listener {
                     new BukkitRunnable() {
                         @Override
                         public void run() {
+                            if (customBossEntity == null || customBossEntity.getLivingEntity() == null)
+                                return;
                             PreventMountExploit.bypass = true;
                             customBossEntity.getLivingEntity().addPassenger(getLivingEntity());
                         }

--- a/src/main/java/com/magmaguy/elitemobs/mobs/passive/ChickenHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobs/passive/ChickenHandler.java
@@ -48,20 +48,11 @@ public class ChickenHandler implements Listener {
     Use events to add and remove loaded chicken and use the scanner to update the list of active chicken
     */
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void superDrops(EntityDamageByEntityEvent event) {
 
-        if (event.isCancelled()) {
-
+        if (event.getFinalDamage() < 1)
             return;
-
-        }
-
-        if (event.getFinalDamage() < 1) {
-
-            return;
-
-        }
 
         if (event.getEntity() instanceof Chicken && EntityTracker.isSuperMob(event.getEntity())) {
 
@@ -103,7 +94,7 @@ public class ChickenHandler implements Listener {
 
     }
 
-    private List<String> lore = new ArrayList<>(Arrays.asList("SuperChicken Egg"));
+    private final List<String> lore = new ArrayList<>(Arrays.asList("SuperChicken Egg"));
 
     //Egg drop chance is based on the underlying timer
     public void dropEggs() {

--- a/src/main/java/com/magmaguy/elitemobs/mobs/passive/CowHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobs/passive/CowHandler.java
@@ -22,7 +22,7 @@ import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Random;
@@ -35,20 +35,11 @@ import static org.bukkit.Material.LEATHER;
  */
 public class CowHandler implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void superDrops(EntityDamageByEntityEvent event) {
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void superDrops(EntityDamageEvent event) {
 
-        if (event.isCancelled()) {
-
+        if (event.getFinalDamage() < 1)
             return;
-
-        }
-
-        if (event.getFinalDamage() < 1) {
-
-            return;
-
-        }
 
         if (event.getEntity() instanceof Cow && EntityTracker.isSuperMob(event.getEntity())) {
 

--- a/src/main/java/com/magmaguy/elitemobs/mobs/passive/MushroomCowHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobs/passive/MushroomCowHandler.java
@@ -22,7 +22,7 @@ import org.bukkit.entity.MushroomCow;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -35,14 +35,11 @@ import static org.bukkit.Material.*;
  */
 public class MushroomCowHandler implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void superDrops(EntityDamageByEntityEvent event) {
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void superDrops(EntityDamageEvent event) {
 
-        if (event.getFinalDamage() < 1) {
-
+        if (event.getFinalDamage() < 1)
             return;
-
-        }
 
         if (event.getEntity() instanceof MushroomCow && EntityTracker.isSuperMob(event.getEntity())) {
 

--- a/src/main/java/com/magmaguy/elitemobs/mobs/passive/PigHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobs/passive/PigHandler.java
@@ -22,7 +22,7 @@ import org.bukkit.entity.Pig;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Random;
@@ -34,20 +34,11 @@ import static org.bukkit.Material.PORKCHOP;
  */
 public class PigHandler implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void superDrops(EntityDamageByEntityEvent event) {
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void superDrops(EntityDamageEvent event) {
 
-        if (event.isCancelled()) {
-
+        if (event.getFinalDamage() < 1)
             return;
-
-        }
-
-        if (event.getFinalDamage() < 1) {
-
-            return;
-
-        }
 
         if (event.getEntity() instanceof Pig && EntityTracker.isSuperMob(event.getEntity())) {
 

--- a/src/main/java/com/magmaguy/elitemobs/mobs/passive/SheepHandler.java
+++ b/src/main/java/com/magmaguy/elitemobs/mobs/passive/SheepHandler.java
@@ -21,7 +21,7 @@ import org.bukkit.entity.Sheep;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.ItemStack;
@@ -36,17 +36,11 @@ import static org.bukkit.Material.*;
  */
 public class SheepHandler implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void superDrops(EntityDamageByEntityEvent event) {
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void superDrops(EntityDamageEvent event) {
 
-        if (event.isCancelled())
+        if (event.getFinalDamage() < 1)
             return;
-
-        if (event.getFinalDamage() < 1) {
-
-            return;
-
-        }
 
         if (EntityTracker.isSuperMob(event.getEntity()) && event.getEntity() instanceof Sheep) {
 

--- a/src/main/java/com/magmaguy/elitemobs/npcs/NPCEntity.java
+++ b/src/main/java/com/magmaguy/elitemobs/npcs/NPCEntity.java
@@ -151,7 +151,7 @@ public class NPCEntity {
         this.spawnLocation.setDirection(this.spawnLocation.getDirection().multiply(-1));
 
         //this is how the wandering trader works
-        if (npCsConfigFields.getLocation().equalsIgnoreCase("null"))
+        if (npCsConfigFields.getLocation() == null || npCsConfigFields.getLocation().equalsIgnoreCase("null"))
             return;
 
         WorldGuardSpawnEventBypasser.forceSpawn();

--- a/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerData.java
+++ b/src/main/java/com/magmaguy/elitemobs/playerdata/PlayerData.java
@@ -3,6 +3,7 @@ package com.magmaguy.elitemobs.playerdata;
 import com.magmaguy.elitemobs.MetadataHandler;
 import com.magmaguy.elitemobs.quests.EliteQuest;
 import com.magmaguy.elitemobs.quests.PlayerQuests;
+import com.magmaguy.elitemobs.utils.DebugMessage;
 import com.magmaguy.elitemobs.utils.WarningMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -14,10 +15,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -378,74 +376,78 @@ public class PlayerData {
 
                         resultSet.close();
                         statement.close();
+                        new DebugMessage("Successfully obtained player data!");
+                        return;
+                    } else {
+                        currency = 0;
+                        guildPrestigeLevel = 0;
+                        maxGuildLevel = 1;
+                        activeGuildLevel = 1;
+                        questStatus = null;
+                        score = 0;
+                        kills = 0;
+                        highestLevelKilled = 0;
+                        deaths = 0;
+                        questsCompleted = 0;
+
+                        playerDataHashMap.put(uuid, playerData);
+
+                        statement = getConnection().createStatement();
+                        String sql = "INSERT INTO " + player_data_table_name +
+                                " (PlayerUUID," +
+                                " DisplayName," +
+                                " Currency," +
+                                " GuildPrestigeLevel," +
+                                " GuildMaxLevel," +
+                                " GuildActiveLevel," +
+                                " Score," +
+                                " Kills," +
+                                " HighestLevelKilled," +
+                                " Deaths," +
+                                " QuestsCompleted) " +
+                                //identifier
+                                "VALUES ('" + uuid.toString() + "'," +
+                                //display name
+                                " '" + Bukkit.getPlayer(uuid).getName() + "'," +
+                                //currency
+                                " 0," +
+                                //guild_prestige_level
+                                " 0," +
+                                //guild_max_level
+                                " 1," +
+                                //guild_active_level
+                                " 1," +
+                                //score
+                                "0," +
+                                //kills
+                                "0," +
+                                //highestLevelKilled
+                                "0," +
+                                //deaths
+                                "0," +
+                                //questsCompleted
+                                "0);";
+                        statement.executeUpdate(sql);
+
+                        statement.close();
+                        new DebugMessage("Successfully generated new player data entry!");
                         return;
                     }
-
-                    resultSet.close();
-                    statement.close();
                 } catch (Exception e) {
+                    if (statement != null) {
+                        try {
+                            statement.close();
+                        } catch (SQLException throwables) {
+                            new WarningMessage("Failed to close statement after failing player data creation!");
+                            throwables.printStackTrace();
+                        }
+                    }
                     new WarningMessage("Something went wrong while generating a new player entry. This is bad! Tell the dev.");
                     System.err.println(e.getClass().getName() + ": " + e.getMessage());
                 }
 
                 new WarningMessage("No player entry detected, generating new entry!");
 
-                try {
-                    statement = getConnection().createStatement();
-                    String sql = "INSERT INTO " + player_data_table_name +
-                            " (PlayerUUID," +
-                            " DisplayName," +
-                            " Currency," +
-                            " GuildPrestigeLevel," +
-                            " GuildMaxLevel," +
-                            " GuildActiveLevel," +
-                            " Score," +
-                            " Kills," +
-                            " HighestLevelKilled," +
-                            " Deaths," +
-                            " QuestsCompleted) " +
-                            //identifier
-                            "VALUES ('" + uuid.toString() + "'," +
-                            //display name
-                            " '" + Bukkit.getPlayer(uuid).getName() + "'," +
-                            //currency
-                            " 0," +
-                            //guild_prestige_level
-                            " 0," +
-                            //guild_max_level
-                            " 1," +
-                            //guild_active_level
-                            " 1," +
-                            //score
-                            "0," +
-                            //kills
-                            "0," +
-                            //highestLevelKilled
-                            "0," +
-                            //deaths
-                            "0," +
-                            //questsCompleted
-                            "0);";
-                    statement.executeUpdate(sql);
-
-                    currency = 0;
-                    guildPrestigeLevel = 0;
-                    maxGuildLevel = 1;
-                    activeGuildLevel = 1;
-                    questStatus = null;
-                    score = 0;
-                    kills = 0;
-                    highestLevelKilled = 0;
-                    deaths = 0;
-                    questsCompleted = 0;
-
-                    playerDataHashMap.put(uuid, playerData);
-
-                    statement.close();
-                } catch (Exception e) {
-                    new WarningMessage("Failed to generate an entry!");
-                    System.err.println(e.getClass().getName() + ": " + e.getMessage());
-                }
             }
         }.runTaskAsynchronously(MetadataHandler.PLUGIN);
     }

--- a/src/main/java/com/magmaguy/elitemobs/powerstances/GenericRotationMatrixMath.java
+++ b/src/main/java/com/magmaguy/elitemobs/powerstances/GenericRotationMatrixMath.java
@@ -66,22 +66,22 @@ public class GenericRotationMatrixMath {
 
     }
 
-    private static Location rotateSpecificLocation(double a, double b, double c, double theta, Location location) {
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
+    private static Vector rotateSpecificLocation(double a, double b, double c, double theta, Vector relativeLocation) {
+        double x = relativeLocation.getX();
+        double y = relativeLocation.getY();
+        double z = relativeLocation.getZ();
         //Convert radian to degree
-        theta *= 180 / PI;
+        theta *= PI / 180;
 
         double newX = x * (cos(theta) + (1 - cos(theta)) * pow(a, 2)) + y * ((1 - cos(theta)) * a * b + (sin(theta)) * c) + z * ((1 - cos(theta)) * a * c - (sin(theta)) * b);
         double newY = x * ((1 - cos(theta)) * b * a - (sin(theta)) * c) + y * (cos(theta) + (1 - cos(theta)) * pow(b, 2)) + z * ((1 - cos(theta)) * b * c + (sin(theta)) * a);
         double newZ = x * ((1 - cos(theta)) * c * a + (sin(theta)) * b) + y * ((1 - cos(theta)) * c * b - (sin(theta)) * a) + z * (cos(theta) + (1 - cos(theta)) * pow(c, 2));
 
-        return new Location(location.getWorld(), newX, newY, newZ);
+        return new Vector(newX, newY, newZ);
     }
 
-    public static Location rotateLocationYAxis(double rotationAngleInDegrees, Location location) {
-        return rotateSpecificLocation(0, 1, 0, rotationAngleInDegrees, location);
+    public static Location rotateLocationYAxis(double rotationAngleInDegrees, Location anchorPoint, Vector relativeLocation) {
+        return anchorPoint.clone().add(rotateSpecificLocation(0, 1, 0, rotationAngleInDegrees, relativeLocation));
     }
 
 }

--- a/src/main/java/com/magmaguy/elitemobs/powerstances/VisualItemInitializer.java
+++ b/src/main/java/com/magmaguy/elitemobs/powerstances/VisualItemInitializer.java
@@ -1,9 +1,11 @@
 package com.magmaguy.elitemobs.powerstances;
 
 import com.magmaguy.elitemobs.EntityTracker;
+import com.magmaguy.elitemobs.MetadataHandler;
 import org.bukkit.Location;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
 
 public class VisualItemInitializer {
 
@@ -13,6 +15,7 @@ public class VisualItemInitializer {
         EntityTracker.registerItemVisualEffects(item);
         item.setGravity(false);
         item.setInvulnerable(true);
+        item.setMetadata(MetadataHandler.BETTERDROPS_COMPATIBILITY_MD, new FixedMetadataValue(MetadataHandler.PLUGIN, true));
 
         return item;
     }

--- a/src/main/java/com/magmaguy/elitemobs/versionnotifier/VersionWarner.java
+++ b/src/main/java/com/magmaguy/elitemobs/versionnotifier/VersionWarner.java
@@ -4,13 +4,13 @@ import com.magmaguy.elitemobs.ChatColorConverter;
 import com.magmaguy.elitemobs.MetadataHandler;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 
 public class VersionWarner implements Listener {
 
     @EventHandler
-    public void onPlayerLogin(PlayerLoginEvent event) {
+    public void onPlayerLogin(PlayerJoinEvent event) {
 
         if (!event.getPlayer().hasPermission("elitemobs.versionnotification")) return;
 
@@ -20,7 +20,7 @@ public class VersionWarner implements Listener {
                 event.getPlayer().sendMessage(ChatColorConverter.convert("&a[EliteMobs] &cYour version of EliteMobs is outdated." +
                         " &aYou can download the latest version from &3&n&ohttps://www.spigotmc.org/resources/%E2%9A%94elitemobs%E2%9A%94.40090/"));
             }
-        }.runTaskLater(MetadataHandler.PLUGIN, 20*3);
+        }.runTaskLater(MetadataHandler.PLUGIN, 20 * 3);
 
 
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EliteMobs
-version: 7.2.9
+version: 7.2.10
 author: MagmaGuy
 main: com.magmaguy.elitemobs.EliteMobs
 api-version: 1.14


### PR DESCRIPTION
- [New] First true iteration of the Dungeon Packager
- [New] Dungeon Packager is now able to scan both WorldEdit and FastAsyncWorldEdit schematics
- [New] Dungeon Packager now accepts user-made packages
- [New] Schematic-based minidungeons can now be loaded and unloaded through the /em setup menu (it's still in the earliest possible phase)
- [Fix] Fixed database error when new players joined
- [Fix] Conduit potion effect now works correctly for items
- [Tweak] Dungeon Packages now have a better detection system
- [Tweak] Now using PlayerLoginEvent only and no PlayerJoinEvents
- [3rd party compatiblity] Added compatiblity for BetterItems
- [Code QOL] Created a standardized system for modifying configuration values from in-game during runtime

Signed-off-by: MagmaGuy <tiagoarnaut@gmail.com>